### PR TITLE
Bugfix: no video controller when not active

### DIFF
--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -9,6 +9,7 @@
       @mouseup="togglePlayback"
       @mousewheel="wheelVolumeControll"
       @mousemove="wakeUpAllWidgets"
+      @mouseover="focusCurrentWindow"
       @mouseout="hideAllWidgets"
       @dblclick.self="toggleFullScreenState">
 			<TimeProgressBar/>
@@ -65,6 +66,9 @@ export default {
         this.cursorShow = false;
       }, 3000);
     },
+    focusCurrentWindow() {
+      this.currentWindow.focus();
+    },
     wakeUpAllWidgets() {
       this.showMask = true;
       this.isDragging = true;
@@ -107,9 +111,6 @@ export default {
   },
   mounted() {
     this.$bus.$emit('play');
-    window.addEventListener('mouseover', () => {
-      this.$electron.remote.getCurrentWindow().focus();
-    });
   },
   computed: {
     uri() {

--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -107,6 +107,9 @@ export default {
   },
   mounted() {
     this.$bus.$emit('play');
+    window.addEventListener('mouseover', () => {
+      this.$electron.remote.getCurrentWindow().focus();
+    });
   },
   computed: {
     uri() {


### PR DESCRIPTION
# Bug(Level A): video controller will not appear when window not focused

## Solution: make the current window get focus
```javascript
window.addEventListener('mouseover', () => {
  this.$electron.remote.getCurrentWindow().focus();
});
```
- Note: When browser window is not active, mouseenter mouseleave will not trigger.

## Reference:
- https://javascript.info/mousemove-mouseover-mouseout-mouseenter-mouseleave
- https://github.com/electron/electron/blob/master/docs/api/browser-window.md#winfocus
- https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps

## To-do

- [ ] Suddenly get focus of a window may be annoying for users, so better solutions are welcome.
- [ ] Pause the video when video is minimized for better performance.
- https://www.w3.org/TR/page-visibility/#examples-of-usage