### PR TITLE
G-R005 responsive widgets

### DIFF
--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -178,9 +178,10 @@ export default {
       return this.widthOfThumbnail / this.videoRatio;
     },
     positionOfScreenshot() {
+      const progressBarWidth = this.currentWindow.getSize()[0] - 20;
       const halfWidthOfScreenshot = this.widthOfThumbnail / 2;
-      const minWidth = this.widthOfThumbnail + 16;
-      const maxWidth = this.currentWindow.getSize()[0] - 16;
+      const minWidth = (this.widthOfThumbnail / 2) + 16;
+      const maxWidth = progressBarWidth - 16;
       if (this.widthOfReadyToPlay < minWidth) {
         return 16;
       } else if (this.widthOfReadyToPlay + halfWidthOfScreenshot > maxWidth) {

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -171,8 +171,8 @@ export default {
       }
     },
     handleResize() {
-      const screenWidth = document.documentElement.clientWidth;
-      const screenHeight = document.documentElement.clientHeight;
+      const screenWidth = this.currentWindow.getSize()[0];
+      const screenHeight = this.currentWindow.getSize()[1];
       const screenSize = {
         screenWidth,
         screenHeight,


### PR DESCRIPTION
## Change
- Use electron's native getSize() API instead of BOM.
- Add progressBarWidth to handle conflicts.

## Fix
- Fix the inappropriate behavior of thumbnail.