### PR TITLE
Fix the traffic light buttons are displayed timing

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -31,11 +31,19 @@ function createWindow() {
       webSecurity: false,
       experimentalFeatures: true,
     },
+
+    // See https://github.com/electron/electron/blob/master/docs/api/browser-window.md#showing-window-gracefully
+    backgroundColor: '#802e2c29',
+    show: false,
   });
 
   mainWindow.loadURL(winURL);
   mainWindow.on('closed', () => {
     mainWindow = null;
+  });
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow.show();
   });
 }
 


### PR DESCRIPTION
When app startup, the traffic light first display before the main window is displaying.