### PR TITLE
Linebreak Style on Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
     'import/newline-after-import': 0,
     'no-multi-assign': 0,
     // allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
+    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
+    // force the use of unix linebreak-syle
+    'linebreak-style': ['error', 'unix'],
   }
 }

--- a/test/unit/specs/MediaQuickHash.spec.js
+++ b/test/unit/specs/MediaQuickHash.spec.js
@@ -1,13 +1,12 @@
 import helpers from '@/helpers';
 
-describe('MediaQuickHash test: ', function() {
-  it('should return correct hash value', function() {
+describe('MediaQuickHash test: ', function () {
+  it('should return correct hash value', function () {
     const expectedResult = '84f0e9e5e05f04b58f53e2617cc9c866-'
                         + 'f54d6eb31bef84839c3ce4fc2f57991c-'
                         + 'b1f0696aec64577228d93eabcc8eb69b-'
                         + 'f497c6684c4c6e50d0856b5328a4bedc';
-    const functionResult = helpers.methods.mediaQuickHash(
-      '../../../test/assets/mediaQuickHash_test.avi');
+    const functionResult = helpers.methods.mediaQuickHash('../../../test/assets/mediaQuickHash_test.avi');
     expect(functionResult).to.be.equal(expectedResult);
   });
 });


### PR DESCRIPTION
## Force the use of UNIX linebreak style on Windows
- In `.eslintrc.js`, add a rule: `linebreak-style: ['error', 'unix'];`.