### PR TITLE
Bug: Windows drag

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -43,6 +43,7 @@ function createWindow() {
   });
 
   mainWindow.once('ready-to-show', () => {
+    mainWindow.webContents.send('dom', process.platform);
     mainWindow.show();
   });
 }

--- a/src/renderer/components/LandingView.vue
+++ b/src/renderer/components/LandingView.vue
@@ -61,6 +61,10 @@ export default {
       lastPlayedFile: [],
       backgroundUrl: '',
       showShortcutImage: false,
+      isDragging: false,
+      mouseDown: false,
+      windowStartPosition: null,
+      mousedownPosition: null,
     };
   },
   components: {
@@ -111,7 +115,7 @@ export default {
       this.$set(this.lastPlayedFile[index], 'chosen', false);
     },
     open(link) {
-      if (this.showingPopupDialog) {
+      if (this.showingPopupDialog || this.isDragging) {
         // skip if there is already a popup dialog
         return;
       }
@@ -142,6 +146,7 @@ export default {
     handleLeftClick(event) {
       // Handle dragging-related variables
       this.mouseDown = true;
+      this.isDragging = false;
       this.windowStartPosition = this.$electron.remote.getCurrentWindow().getPosition();
       this.mousedownPosition = [event.screenX, event.screenY];
     },
@@ -149,6 +154,7 @@ export default {
       // Handle dragging-related variables and methods
       if (this.mouseDown) {
         if (this.windowStartPosition !== null) {
+          this.isDragging = true;
           const startPos = this.mousedownPosition;
           const offset = [event.screenX - startPos[0], event.screenY - startPos[1]];
           const winStartPos = this.windowStartPosition;

--- a/src/renderer/components/LandingView.vue
+++ b/src/renderer/components/LandingView.vue
@@ -1,9 +1,10 @@
 <template>
 <div class="wrapper">
-  <main
-    @mousedown.left.stop.prevent="handleLeftClick"
-    @mouseup.left.stop.prevent="handleMouseUp"
-    @mousemove="handleMouseMove">
+  <main>
+    <div class="mask"
+      @mousedown.left.stop="handleLeftClick"
+      @mouseup.left.stop="handleMouseUp"
+      @mousemove="handleMouseMove"></div>
     <div class="background-image"
       v-if="showShortcutImage">
       <img
@@ -25,7 +26,6 @@
     <div class="welcome">
       <div class="title" v-bind:style="$t('css.titleFontSize')">{{ $t("msg.titleName") }}</div>
     </div>
-
     <div class="controller">
       <div class="playlist"
         v-if="hasRecentPlaylist">
@@ -37,7 +37,7 @@
               width: item.chosen ? '140px' : '114px',
               height: item.chosen ? '80px' : '65px',
             }"
-          @click="openFile(item.path)"
+          @click.stop="openFile(item.path)"
           @mouseover="onRecentItemMouseover(item, index)"
           @mouseout="onRecentItemMouseout(index)">
         </div>
@@ -45,7 +45,7 @@
     </div>
     <div
       @click="open('./')">
-      <img class="button" src="~@/assets/icon-open.svg" type="image/svg+xml">
+      <img class="button" src="~@/assets/icon-open.svg" type="image/svg+xml" style="-webkit-user-drag: none;">
     </div>
   </main>
 </div>
@@ -198,6 +198,7 @@ body {
   position: absolute;
   width: 100%;
   height: 100%;
+  z-index: 2;
 
   .item-name {
     position: absolute;
@@ -227,6 +228,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
+    -webkit-user-drag: none;
   }
 }
 .logo {
@@ -242,6 +244,7 @@ main {
 
 .welcome {
   margin-top: 15px;
+  z-index: 1;
   .title {
     font-size: 7vw;
     margin-bottom: 6px;
@@ -251,6 +254,13 @@ main {
     color: gray;
     margin-bottom: 10px;
   }
+}
+
+.mask {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 3;
 }
 
 .controller {
@@ -280,6 +290,7 @@ main {
       background-repeat: no-repeat;
       background-position: center center;
       transition: width 150ms ease-out, height 150ms ease-out;
+      z-index: 4;
     }
   }
 }
@@ -294,6 +305,7 @@ main {
   outline: none;
   transition: all 0.15s ease;
   border: 0px;
+  z-index: 5;
 }
 
 </style>

--- a/src/renderer/components/LandingView.vue
+++ b/src/renderer/components/LandingView.vue
@@ -1,6 +1,9 @@
 <template>
 <div class="wrapper">
-  <main>
+  <main
+    @mousedown.left.stop.prevent="handleLeftClick"
+    @mouseup.left.stop.prevent="handleMouseUp"
+    @mousemove="handleMouseMove">
     <div class="background-image"
       v-if="showShortcutImage">
       <img
@@ -135,6 +138,29 @@ export default {
           self.openFile(`file:///${item[0]}`);
         }
       });
+    },
+    handleLeftClick(event) {
+      // Handle dragging-related variables
+      this.mouseDown = true;
+      this.windowStartPosition = this.$electron.remote.getCurrentWindow().getPosition();
+      this.mousedownPosition = [event.screenX, event.screenY];
+    },
+    handleMouseMove(event) {
+      // Handle dragging-related variables and methods
+      if (this.mouseDown) {
+        if (this.windowStartPosition !== null) {
+          const startPos = this.mousedownPosition;
+          const offset = [event.screenX - startPos[0], event.screenY - startPos[1]];
+          const winStartPos = this.windowStartPosition;
+          this.$electron.remote.getCurrentWindow().setPosition(
+            winStartPos[0] + offset[0],
+            winStartPos[1] + offset[1],
+          );
+        }
+      }
+    },
+    handleMouseUp() {
+      this.mouseDown = false;
     },
   },
 };

--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -13,7 +13,7 @@
     <div class="video-controller" id="video-controller"
       @mousedown.self="resetDraggingState"
       @mousedown.left.stop.prevent="handleLeftClick"
-      @mouseup.left.stop.prevent="handleMouseUp"
+      @mouseup.left.prevent="handleMouseUp"
       @mousewheel="wheelVolumeControll"
       @mousemove="handleMouseMove"
       @mouseout="hideAllWidgets"

--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -48,6 +48,9 @@ export default {
       showMask: false,
       cursorShow: true,
       cursorDelay: null,
+      mouseDown: false,
+      windowStartPosition: null,
+      mousedownPosition: null,
     };
   },
   methods: {

--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -12,9 +12,10 @@
       v-show="showMask"></div>
     <div class="video-controller" id="video-controller"
       @mousedown.self="resetDraggingState"
-      @mouseup="togglePlayback"
+      @mousedown.left.stop.prevent="handleLeftClick"
+      @mouseup.left.prevent="handleMouseUp"
       @mousewheel="wheelVolumeControll"
-      @mousemove="wakeUpAllWidgets"
+      @mousemove="handleMouseMove"
       @mouseout="hideAllWidgets"
       @dblclick.self="toggleFullScreenState">
       <TimeProgressBar :src="uri" />
@@ -110,6 +111,33 @@ export default {
           this.$store.commit('Volume', 0);
         }
       }
+    },
+    handleLeftClick(event) {
+      // Handle dragging-related variables
+      this.mouseDown = true;
+      this.windowStartPosition = this.$electron.remote.getCurrentWindow().getPosition();
+      this.mousedownPosition = [event.screenX, event.screenY];
+      console.log(this.windowStartPosition);
+    },
+    handleMouseMove(event) {
+      this.wakeUpAllWidgets();
+      // Handle dragging-related variables and methods
+      if (this.mouseDown) {
+        if (this.windowStartPosition !== null) {
+          console.log(this.mousedownPosition);
+          const startPos = this.mousedownPosition;
+          const offset = [event.screenX - startPos[0], event.screenY - startPos[1]];
+          const winStartPos = this.windowStartPosition;
+          this.$electron.remote.getCurrentWindow().setPosition(
+            winStartPos[0] + offset[0],
+            winStartPos[1] + offset[1],
+          );
+        }
+      }
+    },
+    handleMouseUp() {
+      this.mouseDown = false;
+      this.togglePlayback();
     },
     pauseIconPause() {
       this.$refs.pauseIcon.style.animationPlayState = 'paused';

--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -13,7 +13,7 @@
     <div class="video-controller" id="video-controller"
       @mousedown.self="resetDraggingState"
       @mousedown.left.stop.prevent="handleLeftClick"
-      @mouseup.left.prevent="handleMouseUp"
+      @mouseup.left.stop.prevent="handleMouseUp"
       @mousewheel="wheelVolumeControll"
       @mousemove="handleMouseMove"
       @mouseout="hideAllWidgets"
@@ -117,14 +117,12 @@ export default {
       this.mouseDown = true;
       this.windowStartPosition = this.$electron.remote.getCurrentWindow().getPosition();
       this.mousedownPosition = [event.screenX, event.screenY];
-      console.log(this.windowStartPosition);
     },
     handleMouseMove(event) {
       this.wakeUpAllWidgets();
       // Handle dragging-related variables and methods
       if (this.mouseDown) {
         if (this.windowStartPosition !== null) {
-          console.log(this.mousedownPosition);
           const startPos = this.mousedownPosition;
           const offset = [event.screenX - startPos[0], event.screenY - startPos[1]];
           const winStartPos = this.windowStartPosition;

--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="progress-container" ref="sliderContainer"
       :style="{width: this.$electron.remote.getCurrentWindow().getSize()[0] - 20 + 'px'}"
-      @mousedown.left="onProgresssBarClick">
+      @mousedown.left.stop="onProgresssBarClick">
       <div class="screenshot-background"
         v-show="showScreenshot"
         :style="{ left: positionOfScreenshot +'px', width: widthOfThumbnail + 'px', height: heightofScreenshot +'px' }">

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -304,5 +304,10 @@ new Vue({
     window.addEventListener('dragover', (e) => {
       e.preventDefault();
     });
+    require('electron').ipcRenderer.once('dom', (event, message) => {
+      if (message === 'win32') {
+        document.querySelector('.application').style.webkitAppRegion = 'no-drag';
+      }
+    });
   },
 }).$mount('#app');


### PR DESCRIPTION
## Bug: Windows Drag

- Problem Description: `-webkit-app-region: drag;` can't work properly on Windows. It will block all mouse events.
### Solution
- Disable `-webkit-app-region: drag;` on Windows.
- Use custom drag instead.
#### Custom Drag (Only consider left button)
- When mousedown, store current mousedown position as mousedownPosition and window position as startWindowPosition, then set mouseDown true.
- When mousemove, if mouseDown is true, consider current action is dragging.
- When dragging, calculate offset: = [current mousemove position - mousedown position]. Then set window position to [offset position  + startWindowPosition,].
- When mouseup, set mouseDown to false.