### PR TITLE
Bugs: Fix Appveyor and Travis.ci build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
       "output": "build"
     },
     "electronDownload": {
-      "verifyChecksum": false
+      "isVerifyChecksum": false,
+      "version": "2.0.3"
     },
     "files": [
       "dist/electron/**/*"


### PR DESCRIPTION
## Bug: electron-builder failure
- `Appveyor`和`Travis.ci`都将`electron-builder`更新到了最新的版本`20.19.1`；
- 新版本中强制要求`package.json`的`build`中的`electronDownload`字段提供`version`选项，而且将`verifyChecksum`更改为`isVerifyChecksum`。
- 更改了package.json，使`Appveyor`和`Travis.ci`可以通过。