### PR TITLE
修复electron-builder更新到最新版打包报错的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": null,
   "main": "./dist/electron/main.js",
   "scripts": {
-    "build": "node .electron-vue/build.js && electron-builder",
+    "build": "node .electron-vue/build.js && DEBUG=electron-download electron-builder",
     "build:dir": "node .electron-vue/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",
     "build:web": "cross-env BUILD_TARGET=web node .electron-vue/build.js",
@@ -33,8 +33,9 @@
       "output": "build"
     },
     "electronDownload": {
+      "mirror": "https://github.com/chiflix/electron/releases/download/v",
       "isVerifyChecksum": false,
-      "version": "2.0.3"
+      "version": "2.0.2"
     },
     "files": [
       "dist/electron/**/*"
@@ -103,7 +104,7 @@
     "css-loader": "^0.28.11",
     "del": "^3.0.0",
     "devtron": "^1.4.0",
-    "electron-builder": "^20.15.0",
+    "electron-builder": "^20.19.2",
     "electron-debug": "^1.4.0",
     "electron-devtools-installer": "^2.2.4",
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": null,
   "main": "./dist/electron/main.js",
   "scripts": {
-    "build": "node .electron-vue/build.js && DEBUG=electron-download electron-builder",
+    "build": "node .electron-vue/build.js && cross-env DEBUG=electron-download electron-builder",
     "build:dir": "node .electron-vue/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",
     "build:web": "cross-env BUILD_TARGET=web node .electron-vue/build.js",


### PR DESCRIPTION
当前PR已经将builder更新到了最新版。

- electronDownload里的version参数官方刚刚修复了强制version的bug

- 另外，我开启了builder的日志，方便查看打包细节

- **还有一个需要注意**：虽然这个version可选配置，但是为了版本发布的正确性，最好还是正确指定一下将要打包的产品使用哪个版本的electron

- **由于我们有自己的electron编译包，所以builder的打包electron下载地址一定是像这样的https://github.com/chiflix/electron/releases/download/v{.........}.zip**
