### PR TITLE
Improve progress bar restart-button

### DIFF
--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -559,9 +559,6 @@ export default {
   animation-iteration-count: infinite;
 }
 
-.shake:hover {
-}
-
 @keyframes shake {
   25% {
     transform: rotate(4deg);

--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -108,6 +108,8 @@ export default {
         this.isOnProgress = false;
         this.showScreenshot = false;
         this.$_resetRestartButton();
+        // 通过设置延时函数，回避backSlider突变到0产生的视觉问题
+        setTimeout(() => { this.cursorPosition = 0; }, 300);
 
         this.$refs.playedSlider.style.height = PROGRESS_BAR_SLIDER_HIDE_HEIGHT;
         this.$refs.foolProofBar.style.height = PROGRESS_BAR_SLIDER_HIDE_HEIGHT;
@@ -250,6 +252,11 @@ export default {
       return (this.$store.state.PlaybackState.AccurateTime
         / this.$store.state.PlaybackState.Duration) * progressBarWidth;
     },
+    /**
+     * when cursor is not on progress bar, the cursor position
+     * should be the current progress bar edge to ensure the 
+     * progress bar display correctly.
+     */
     cursorState() {
       if (this.isOnProgress) {
         return this.cursorPosition;
@@ -317,7 +324,7 @@ export default {
     });
     this.$bus.$on('progressslider-appear', () => {
       this.showScreenshot = false;
-      this.cursorPosition = 0;
+      // this.cursorPosition = 0;
       this.appearProgressSlider();
       this.isOnProgress = false;
       if (this.timeoutIdOfProgressBarDisappearDelay !== 0) {

--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -3,7 +3,7 @@
     <!-- 用mouseout监听会在经过两个div的分界处触发事件 -->
   <div class="progress"
     @mouseover.stop.capture="appearProgressSlider"
-    @mouseleave="hideProgressSlider"
+    @mouseout.stop.capture.prevent="hideProgressSlider"
     @mousemove="onProgresssBarMove"
     v-show="showProgressBar">
     <div class="fool-proof-bar" ref="foolProofBar"
@@ -85,6 +85,7 @@ export default {
       isOnProgress: false,
       isShaking: false,
       timeoutIdOfProgressBarDisappearDelay: 0,
+      timeoutIdOfBackBarDisapppearDelay: 0,
       percentageOfReadyToPlay: 0,
       cursorPosition: 0,
       videoRatio: 0,
@@ -98,6 +99,9 @@ export default {
   methods: {
     appearProgressSlider() {
       this.isOnProgress = true;
+      if (this.timeoutIdOfBackBarDisapppearDelay !== 0) {
+        clearTimeout(this.timeoutIdOfBackBarDisapppearDelay);
+      }
       this.$refs.playedSlider.style.height = PROGRESS_BAR_HEIGHT;
       this.$refs.readySlider.style.height = PROGRESS_BAR_HEIGHT;
       this.$refs.foolProofBar.style.height = PROGRESS_BAR_HEIGHT;
@@ -109,7 +113,9 @@ export default {
         this.showScreenshot = false;
         this.$_resetRestartButton();
         // 通过设置延时函数，回避backSlider突变到0产生的视觉问题
-        setTimeout(() => { this.cursorPosition = 0; }, 300);
+        console.log(1231443214132);
+        this.timeoutIdOfBackBarDisapppearDelay =
+         setTimeout(() => { this.cursorPosition = 0; }, 600);
 
         this.$refs.playedSlider.style.height = PROGRESS_BAR_SLIDER_HIDE_HEIGHT;
         this.$refs.foolProofBar.style.height = PROGRESS_BAR_SLIDER_HIDE_HEIGHT;
@@ -175,7 +181,6 @@ export default {
     $_effectProgressBarDraged(e) {
       const cursorPosition = e.clientX - FOOL_PROOFING_BAR_WIDTH;
       this.cursorPosition = cursorPosition;
-      // console.log(this.cursorPosition);
       if (cursorPosition < this.curProgressBarEdge) {
         this.isCursorLeft = true;
       } else {
@@ -271,7 +276,7 @@ export default {
       if (this.cursorPosition <= 0) {
         return 0;
       }
-      return this.isCursorLeft ? this.cursorPosition + 0.1 : 0;
+      return this.isCursorLeft ? this.cursorPosition : 0;
     },
     progressOpacity() {
       if (this.isOnProgress) {
@@ -301,9 +306,10 @@ export default {
   },
   watch: {
     cursorPosition(newVal, oldVal) {
-      if (newVal < oldVal && this.isOnProgress && newVal <= 0) {
+      if (newVal < oldVal && this.isOnProgress && newVal <= 0 && oldVal <= 0) {
         this.buttonWidth = this.cursorPosition <= -6 ? 14 : 20 + this.cursorPosition;
         this.buttonRadius = Math.abs(this.cursorPosition);
+        console.log('watch');
         this.isShaking = true;
       } else {
         this.$_resetRestartButton();
@@ -324,7 +330,6 @@ export default {
     });
     this.$bus.$on('progressslider-appear', () => {
       this.showScreenshot = false;
-      // this.cursorPosition = 0;
       this.appearProgressSlider();
       this.isOnProgress = false;
       if (this.timeoutIdOfProgressBarDisappearDelay !== 0) {

--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -254,7 +254,7 @@ export default {
     },
     /**
      * when cursor is not on progress bar, the cursor position
-     * should be the current progress bar edge to ensure the 
+     * should be the current progress bar edge to ensure the
      * progress bar display correctly.
      */
     cursorState() {

--- a/src/renderer/components/PlayingView/TimeProgressBar.vue
+++ b/src/renderer/components/PlayingView/TimeProgressBar.vue
@@ -3,7 +3,7 @@
     <!-- 用mouseout监听会在经过两个div的分界处触发事件 -->
   <div class="progress"
     @mouseover.stop.capture="appearProgressSlider"
-    @mouseout.stop.capture.prevent="hideProgressSlider"
+    @mouseleave="hideProgressSlider"
     @mousemove="onProgresssBarMove"
     v-show="showProgressBar">
     <div class="fool-proof-bar" ref="foolProofBar"
@@ -99,9 +99,6 @@ export default {
   methods: {
     appearProgressSlider() {
       this.isOnProgress = true;
-      if (this.timeoutIdOfBackBarDisapppearDelay !== 0) {
-        clearTimeout(this.timeoutIdOfBackBarDisapppearDelay);
-      }
       this.$refs.playedSlider.style.height = PROGRESS_BAR_HEIGHT;
       this.$refs.readySlider.style.height = PROGRESS_BAR_HEIGHT;
       this.$refs.foolProofBar.style.height = PROGRESS_BAR_HEIGHT;
@@ -112,10 +109,6 @@ export default {
         this.isOnProgress = false;
         this.showScreenshot = false;
         this.$_resetRestartButton();
-        // 通过设置延时函数，回避backSlider突变到0产生的视觉问题
-        console.log(1231443214132);
-        this.timeoutIdOfBackBarDisapppearDelay =
-         setTimeout(() => { this.cursorPosition = 0; }, 600);
 
         this.$refs.playedSlider.style.height = PROGRESS_BAR_SLIDER_HIDE_HEIGHT;
         this.$refs.foolProofBar.style.height = PROGRESS_BAR_SLIDER_HIDE_HEIGHT;
@@ -181,7 +174,7 @@ export default {
     $_effectProgressBarDraged(e) {
       const cursorPosition = e.clientX - FOOL_PROOFING_BAR_WIDTH;
       this.cursorPosition = cursorPosition;
-      if (cursorPosition < this.curProgressBarEdge) {
+      if (cursorPosition <= this.curProgressBarEdge) {
         this.isCursorLeft = true;
       } else {
         this.isCursorLeft = false;
@@ -272,7 +265,6 @@ export default {
       return this.isCursorLeft ? 0 : Math.abs(this.curProgressBarEdge - this.cursorState);
     },
     backBarWidth() {
-      // 当isOnPorgress为false，backBarWidth为0，增加一个opacity transition的class，避免消失过快
       if (this.cursorPosition <= 0) {
         return 0;
       }
@@ -313,6 +305,17 @@ export default {
         this.isShaking = true;
       } else {
         this.$_resetRestartButton();
+      }
+    },
+    isOnProgress(newVal) {
+      if (newVal) {
+        if (this.timeoutIdOfBackBarDisapppearDelay !== 0) {
+          clearTimeout(this.timeoutIdOfBackBarDisapppearDelay);
+        }
+      } else {
+        // 通过设置延时函数，回避backSlider突变到0产生的视觉问题
+        this.timeoutIdOfBackBarDisapppearDelay =
+         setTimeout(() => { this.cursorPosition = 0; }, 3000);
       }
     },
   },


### PR DESCRIPTION
1. Removed isOnProgress in Watchers and replaced it with mouseenter & mouseleave event on restart-button.
2. Avoid back progress bar disappear abruptly by using setTimeout method to reset the width of back progress bar to zero