### PR TITLE
BugFix: progressbar unproper display on Mac OS X

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -65,9 +65,7 @@ function createWindow() {
   });
 }
 
-app.on('ready', () => {
-  app.setName('SPlayerX');
-  createWindow();
+function initMainWindowEvent() {
   mainWindow.on('resize', () => {
     mainWindow.webContents.send('mainCommit', 'windowSize', mainWindow.getSize());
     mainWindow.webContents.send('mainCommit', 'fullscreen', mainWindow.isFullScreen());
@@ -84,6 +82,12 @@ app.on('ready', () => {
     mainWindow.setPosition(...args);
     event.sender.send('windowPositionChange-asyncReply', mainWindow.getPosition());
   });
+}
+
+app.on('ready', () => {
+  app.setName('SPlayerX');
+  createWindow();
+  initMainWindowEvent();
 });
 
 app.on('window-all-closed', () => {
@@ -95,5 +99,6 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   if (mainWindow === null) {
     createWindow();
+    initMainWindowEvent();
   }
 });


### PR DESCRIPTION
Fix the bug that when OS X users close application and reopen it, the progress bar can not show current progress.