### PR TITLE
fixed the bug mouse causing video pause and play not behave correctly. do a trade off for mac when window is not focused

### DIFF
--- a/src/renderer/components/PlayingView.vue
+++ b/src/renderer/components/PlayingView.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="player"
   :style="{ cursor: cursorStyle }">
-    <VideoCanvas :src="uri" />
+    <VideoCanvas :src="uri" ref="VideoCanvasRef"/>
     <div class="masking"
       v-show="showMask"></div>
     <div class="video-controller" id="video-controller"
       @mousedown.self="resetDraggingState"
       @mousedown.right.stop="handleRightClick"
       @mousedown.left.stop.prevent="handleLeftClick"
-      @mouseup.left.prevent.self="handleMouseUp"
+      @mouseup.left.prevent="handleMouseUp"
       @mousewheel="wheelVolumeControll"
       @mouseleave="mouseleaveHandler"
       @mousemove.self="throttledWakeUpCall"
-      @mouseenter="wakeUpAllWidgets">
+      @mouseenter="mouseEnter">
       <titlebar currentView="Playingview"></titlebar>
       <TimeProgressBar :src="uri" />
       <TheTimeCodes/>
@@ -34,6 +34,7 @@ import VolumeControl from './PlayingView/VolumeControl.vue';
 import AdvanceControl from './PlayingView/AdvanceControl.vue';
 import SubtitleControl from './PlayingView/SubtitleControl.vue';
 import PlayButton from './PlayingView/PlayButton.vue';
+import UnfousedHelper from './PlayingView/helpers/macUnfocusHelper.js';
 
 export default {
   name: 'playing-view',
@@ -62,7 +63,16 @@ export default {
       delay: 200, // changable and should be discussed.
       clicks: 0,
       timer: null,
+      mainWindow: null,
+      unfocusedHelper: null,
+      dragRadiusSquare: 25,
+      dragTime: 200,
+      mouseDownTime: null,
+      mouseDownCursorPosition: null,
     };
+  },
+  created() {
+    this.mainWindow = this.$electron.remote.getCurrentWindow();
   },
   methods: {
     toggleFullScreenState() {
@@ -89,23 +99,30 @@ export default {
         if (this.timeoutIdOfAllWidgetsDisappearDelay !== 0) {
           clearTimeout(this.timeoutIdOfAllWidgetsDisappearDelay);
           this.timeoutIdOfAllWidgetsDisappearDelay
-            = setTimeout(this.hideAllWidgets, 3000);
+              = setTimeout(this.hideAllWidgets, 3000);
         } else {
           this.timeoutIdOfAllWidgetsDisappearDelay
-            = setTimeout(this.hideAllWidgets, 3000);
+              = setTimeout(this.hideAllWidgets, 3000);
         }
       }
       this.leave = false;
     },
+    mouseEnter() {
+      console.log(document.hidden);
+      if (this.unfocusedHelper.needHandle()) {
+        this.wakeUpAllWidgets();
+      }
+    },
     mouseleaveHandler() {
+      if (!this.unfocusedHelper.needHandle()) return;
       this.leave = true;
       if (this.timeoutIdOfAllWidgetsDisappearDelay !== 0) {
         clearTimeout(this.timeoutIdOfAllWidgetsDisappearDelay);
         this.timeoutIdOfAllWidgetsDisappearDelay
-         = setTimeout(this.hideAllWidgets, 1500);
+            = setTimeout(this.hideAllWidgets, 1500);
       } else {
         this.timeoutIdOfAllWidgetsDisappearDelay
-         = setTimeout(this.hideAllWidgets, 1500);
+            = setTimeout(this.hideAllWidgets, 1500);
       }
     },
     hideAllWidgets() {
@@ -125,9 +142,7 @@ export default {
       this.isDragging = false;
     },
     togglePlayback() {
-      if (!this.isDragging) {
-        this.$bus.$emit('toggle-playback');
-      }
+      this.$bus.$emit('toggle-playback');
     },
     wheelVolumeControll(e) {
       this.$bus.$emit('volumecontroller-appear-delay');
@@ -160,6 +175,8 @@ export default {
       }
     },
     handleLeftClick() {
+      this.mouseDownCursorPosition = this.$electron.screen.getCursorScreenPoint();
+      this.mouseDownTime = new Date();
       const menu = this.$electron.remote.Menu.getApplicationMenu();
       if (this.popupShow === true) {
         menu.closePopup();
@@ -167,8 +184,10 @@ export default {
       }
       // Handle dragging-related variables
       this.mouseDown = true;
+      return false;
     },
     handleMouseMove() {
+      if (!this.unfocusedHelper.needHandle()) return;
       this.wakeUpAllWidgets();
     },
     handleMouseUp() {
@@ -176,21 +195,38 @@ export default {
       this.clicks += 1; // one click(mouseUp) triggered, clicks + 1
       if (this.clicks === 1) { // if one click has been detected - clicks === 1
         const self = this; // define a constant "self" for the following scope to use
-        this.timer = setTimeout(() => { // define timer as setTimeOut function
-          self.togglePlayback(); // which is togglePlayback
-          self.clicks = 0; // reset the "clicks" to zero for next event
-        }, this.delay);
+        if (this.isValidClick()) {
+          this.timer = setTimeout(() => { // define timer as setTimeOut function
+            self.togglePlayback(); // which is togglePlayback
+            self.clicks = 0; // reset the "clicks" to zero for next event
+          }, this.delay);
+        } else {
+          self.clicks = 0;
+        }
       } else { // else, if a second click has been detected - clicks === 2
         clearTimeout(this.timer); // cancel the time out
         this.toggleFullScreenState();
         this.clicks = 0;// reset the "clicks" to zero
       }
     },
+    isValidClick() { // this check will be at on mouse up
+      const cp = this.$electron.screen.getCursorScreenPoint();
+      if (new Date() - this.mouseDownTime > this.dragTime) {
+        return false;
+      }
+      const radiusSquare = ((cp.x - this.mouseDownCursorPosition.x) ** 2) +
+          ((cp.y - this.mouseDownCursorPosition.y) ** 2);
+      if (radiusSquare - this.dragRadiusSquare > 0) {
+        return false;
+      }
+      return true;
+    },
   },
   beforeMount() {
-    this.throttledWakeUpCall = _.throttle(this.wakeUpAllWidgets, 1000);
+    this.throttledWakeUpCall = _.throttle(this.handleMouseMove, 1000);
   },
   mounted() {
+    this.unfocusedHelper = new (UnfousedHelper())(this.mainWindow, this);
     this.$bus.$emit('play');
     this.$electron.remote.getCurrentWindow().setResizable(true);
     this.$bus.$on('clear-all-widget-disappear-delay', () => {

--- a/src/renderer/components/PlayingView/helpers/macUnfocusHelper.js
+++ b/src/renderer/components/PlayingView/helpers/macUnfocusHelper.js
@@ -1,0 +1,50 @@
+export class UnfocusedHelper {
+  constructor() {
+    this.True = true;
+  }
+  needHandle() {
+    return this.True;
+  }
+}
+
+export class UnfocusedHelperForMac extends UnfocusedHelper {
+  constructor(win, vue) {
+    super();
+    this.win = win;
+    this.vue = vue;
+    this.bus = this.vue.$bus;
+    this.videoCanvas = this.vue.$refs.VideoCanvasRef.$refs.videoCanvas;
+    this.win.on('focus', () => { this.onFocus(); });
+  }
+  needHandle() {
+    if (!this.win.isFocused()) {
+      return false;
+    }
+    return true;
+  }
+  onFocus() {
+    if (this.videoCanvas.paused) {
+      if (this.cursorInWindow()) {
+        this.bus.$emit('play');
+      }
+    } else {
+      this.vue.wakeUpAllWidgets();
+      // this.bus.$emit('pause');
+    }
+  }
+  cursorInWindow() {
+    const cp = this.vue.$electron.screen.getCursorScreenPoint();
+    const wb = this.win.getBounds();
+    if (wb.x < cp.x && cp.x < (wb.x + wb.width) && wb.y < cp.y && cp.y < (wb.y + wb.height)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+export default function getHelper() {
+  if (process.platform === 'darwin') {
+    return UnfocusedHelperForMac;
+  }
+  return UnfocusedHelper;
+}

--- a/test/unit/specs/PlayingView.spec.js
+++ b/test/unit/specs/PlayingView.spec.js
@@ -163,7 +163,7 @@ function videoCanvasMock(vue, bus) {
   vue.$refs.VideoCanvasRef.$refs.videoCanvas = vcanvas;
   return vcanvas;
 }
-describe.only('PlayingView.vue.lyc', () => {
+describe('PlayingView.vue.lyc', () => {
   let store;
   let timer; //eslint-disable-line
   beforeEach(() => {

--- a/test/unit/specs/PlayingView.spec.js
+++ b/test/unit/specs/PlayingView.spec.js
@@ -4,7 +4,8 @@ import Vuex from 'vuex';
 import PlaybackState from '@/store/modules/PlaybackState';
 import sinon from 'sinon';
 import PlayingView from '@/components/PlayingView';
-
+import EventEmitter from 'events';
+import { UnfocusedHelperForMac } from '../../../src/renderer/components/PlayingView/helpers/macUnfocusHelper.js';
 const localVue = createLocalVue();
 
 localVue.use(Vuex);
@@ -22,6 +23,9 @@ describe('PlayingView.vue', () => {
         },
       },
     });
+  });
+  afterEach(() => {
+    sinon.restore();
   });
   it('correct data when mounted', () => {
     const wrapper = shallowMount(PlayingView, ({ store, localVue }));
@@ -69,3 +73,193 @@ describe('PlayingView.vue', () => {
     spy.restore();
   });
 });
+class Screen {
+  constructor(win) {
+    this.win = win;
+  }
+  getCursorScreenPoint() {
+    return this.win.cursor;
+  }
+}
+class Window {
+  constructor() {
+    this.bounds = {
+      x: 0, y: 0, width: 100, height: 100,
+    };
+    this.screen = new Screen(this);
+    this.evnt = new EventEmitter();
+    this.cursor = { x: 0, y: 0 };
+    this.focus = false;
+  }
+  getSize() {
+    return [this.bounds.width, this.bounds.height];
+  }
+  isFocused() {
+    return this.focus;
+  }
+  focusWindow() {
+    if (!this.focus) {
+      this.evnt.emit('focus');
+    }
+    this.focus = true;
+  }
+  getBounds() {
+    return this.bounds;
+  }
+  setSize(width, height) {
+    if (this.bounds.width === width && this.bounds.height === height) return;
+    this.bounds.width = width;
+    this.bounds.height = height;
+    this.evnt.emit('resize', null);
+  }
+  on(msg, callback) {
+    return this.evnt.on(msg, callback);
+  }
+}
+class VideoCanvas {
+  constructor(bus) {
+    this.paused = false;
+    this.$bus = bus;
+    this.$bus.$on('toggle-playback', () => {
+      this.paused = !this.paused;
+    });
+    this.$bus.$on('play', () => {
+      this.play();
+    });
+    this.$bus.$on('pause', () => {
+      this.pause();
+    });
+  }
+  play() {
+    this.paused = false;
+  }
+  pause() {
+    this.paused = true;
+  }
+}
+function windowMock(vue) {
+  const win = new Window();
+  vue.mainWindow = win;
+  return win;
+}
+function electronMock(vue, win) {
+  vue.$electron = {
+    screen: win.screen,
+    remote: { Menu: { getApplicationMenu: () => ({ closePopup: () => {} }) } },
+  };
+  return vue.$electron;
+}
+function busMock(vue) {
+  const evnt = new EventEmitter();
+  vue.$bus = {
+    $on: (msg, callback) => { evnt.on(msg, callback); },
+    $emit: (msg) => { evnt.emit(msg); },
+  };
+  return vue.$bus;
+}
+function videoCanvasMock(vue, bus) {
+  const vcanvas = new VideoCanvas(bus);
+  busMock(vcanvas);
+  vue.$refs.VideoCanvasRef.$refs.videoCanvas = vcanvas;
+  return vcanvas;
+}
+describe.only('PlayingView.vue.lyc', () => {
+  let store;
+  let timer; //eslint-disable-line
+  beforeEach(() => {
+    timer = sinon.useFakeTimers();
+    // state = PlaybackState.state;
+    store = new Vuex.Store({
+      modules: {
+        PlaybackState: {
+          state: PlaybackState.state,
+          getters: PlaybackState.getters,
+        },
+      },
+    });
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+  /*
+     * test for mac for not focused
+     * test for click pause and stop bug fix
+     */
+  it('test for mac for on focus when video is playing', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const vue = wrapper.vm;
+    electronMock(vue, windowMock(vue));
+    const win = vue.mainWindow;
+    videoCanvasMock(vue, busMock(vue));
+    vue.unfocusedHelper = new UnfocusedHelperForMac(vue.mainWindow, vue);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    win.focusWindow();
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+  });
+  it('test for mac for on focus when video is not playing', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const vue = wrapper.vm;
+    electronMock(vue, windowMock(vue));
+    videoCanvasMock(vue, busMock(vue));
+    vue.$refs.VideoCanvasRef.$refs.videoCanvas.pause();
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(true);
+    const win = vue.mainWindow;
+    vue.unfocusedHelper = new UnfocusedHelperForMac(vue.mainWindow, vue);
+    win.cursor = { x: 50, y: 50 };
+    win.focusWindow();
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+  });
+  it('test for when click center validly', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const vue = wrapper.vm;
+    electronMock(vue, windowMock(vue));
+    const win = vue.mainWindow;
+    videoCanvasMock(vue, busMock(vue));
+    vue.unfocusedHelper = new UnfocusedHelperForMac(vue.mainWindow, vue);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    win.cursor = { x: 50, y: 50 };
+    win.focusWindow();
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    vue.handleLeftClick();
+    timer.tick(100);
+    vue.handleMouseUp();
+    timer.tick(200);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(true);
+  });
+  it('test for when click center not validly by time', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const vue = wrapper.vm;
+    electronMock(vue, windowMock(vue));
+    const win = vue.mainWindow;
+    videoCanvasMock(vue, busMock(vue));
+    vue.unfocusedHelper = new UnfocusedHelperForMac(vue.mainWindow, vue);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    win.cursor = { x: 50, y: 50 };
+    win.focusWindow();
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    vue.handleLeftClick();
+    timer.tick(300);
+    vue.handleMouseUp();
+    timer.tick(200);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+  });
+  it('test for when click center not validly by space', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const vue = wrapper.vm;
+    electronMock(vue, windowMock(vue));
+    const win = vue.mainWindow;
+    videoCanvasMock(vue, busMock(vue));
+    vue.unfocusedHelper = new UnfocusedHelperForMac(vue.mainWindow, vue);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    win.cursor = { x: 50, y: 50 };
+    win.focusWindow();
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+    vue.handleLeftClick();
+    timer.tick(100);
+    win.cursor = { x: 45, y: 51 };
+    vue.handleMouseUp();
+    timer.tick(200);
+    expect(vue.$refs.VideoCanvasRef.$refs.videoCanvas.paused).equal(false);
+  });
+});
+

--- a/test/unit/specs/PlayingView.spec.js
+++ b/test/unit/specs/PlayingView.spec.js
@@ -5,74 +5,7 @@ import PlaybackState from '@/store/modules/PlaybackState';
 import sinon from 'sinon';
 import PlayingView from '@/components/PlayingView';
 import EventEmitter from 'events';
-import { UnfocusedHelperForMac } from '../../../src/renderer/components/PlayingView/helpers/macUnfocusHelper.js';
-const localVue = createLocalVue();
-
-localVue.use(Vuex);
-
-describe('PlayingView.vue', () => {
-  let store;
-
-  beforeEach(() => {
-    // state = PlaybackState.state;
-    store = new Vuex.Store({
-      modules: {
-        PlaybackState: {
-          state: PlaybackState.state,
-          getters: PlaybackState.getters,
-        },
-      },
-    });
-  });
-  afterEach(() => {
-    sinon.restore();
-  });
-  it('correct data when mounted', () => {
-    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
-    expect(wrapper.vm.leave).equal(false);
-    expect(wrapper.vm.isDragging).equal(false);
-    expect(wrapper.vm.showMask).equal(false);
-    expect(wrapper.vm.cursorShow).equal(true);
-    expect(wrapper.vm.popupShow).equal(false);
-    expect(wrapper.vm.mouseDown).equal(false);
-    expect(wrapper.vm.timeoutIdOfAllWidgetsDisappearDelay).equal(0);
-    expect(wrapper.vm.delay).equal(200);
-    expect(wrapper.vm.clicks).equal(0);
-  });
-  // 待完善
-  it('mouseleave event trigger', () => {
-    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
-    wrapper.find('.video-controller').trigger('mouseleave');
-    expect(wrapper.vm.leave).equal(true);
-  });
-  it('hideAllWidgets method works fine', () => {
-    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
-    const globalEventBusEmitSpy = sinon.spy(wrapper.vm.$bus, '$emit');
-    wrapper.vm.hideAllWidgets();
-
-    // whether event bus works fine
-    expect(globalEventBusEmitSpy.callCount).equal(6);
-    expect(globalEventBusEmitSpy.calledWith('volumecontroller-hide')).equal(true);
-    expect(globalEventBusEmitSpy.calledWith('progressbar-hide')).equal(true);
-    expect(globalEventBusEmitSpy.calledWith('timecode-hide')).equal(true);
-    expect(globalEventBusEmitSpy.calledWith('sub-ctrl-hide')).equal(true);
-    expect(globalEventBusEmitSpy.calledWith('titlebar-hide')).equal(true);
-
-    expect(wrapper.vm.cursorShow).equal(false);
-    globalEventBusEmitSpy.restore();
-  });
-
-  it('Im so DOPE', () => {
-    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
-    const stub = sinon.stub(wrapper.vm.$bus, '$on');
-    stub.yields();
-    const spy = sinon.spy(wrapper.vm, 'hideAllWidgets');
-    stub('hideAllWidgets', spy);
-    expect(spy.calledOnce).equal(true);
-    stub.restore();
-    spy.restore();
-  });
-});
+import { UnfocusedHelperForMac, UnfocusedHelper } from '../../../src/renderer/components/PlayingView/helpers/macUnfocusHelper.js';
 class Screen {
   constructor(win) {
     this.win = win;
@@ -163,6 +96,74 @@ function videoCanvasMock(vue, bus) {
   vue.$refs.VideoCanvasRef.$refs.videoCanvas = vcanvas;
   return vcanvas;
 }
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('PlayingView.vue', () => {
+  let store;
+
+  beforeEach(() => {
+    // state = PlaybackState.state;
+    store = new Vuex.Store({
+      modules: {
+        PlaybackState: {
+          state: PlaybackState.state,
+          getters: PlaybackState.getters,
+        },
+      },
+    });
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+  it('correct data when mounted', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    expect(wrapper.vm.leave).equal(false);
+    expect(wrapper.vm.isDragging).equal(false);
+    expect(wrapper.vm.showMask).equal(false);
+    expect(wrapper.vm.cursorShow).equal(true);
+    expect(wrapper.vm.popupShow).equal(false);
+    expect(wrapper.vm.mouseDown).equal(false);
+    expect(wrapper.vm.timeoutIdOfAllWidgetsDisappearDelay).equal(0);
+    expect(wrapper.vm.delay).equal(200);
+    expect(wrapper.vm.clicks).equal(0);
+  });
+  // 待完善
+  it('mouseleave event trigger', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    wrapper.vm.unfocusedHelper = new UnfocusedHelper(); // use default one
+    wrapper.find('.video-controller').trigger('mouseleave');
+    expect(wrapper.vm.leave).equal(true);
+  });
+  it('hideAllWidgets method works fine', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const globalEventBusEmitSpy = sinon.spy(wrapper.vm.$bus, '$emit');
+    wrapper.vm.hideAllWidgets();
+
+    // whether event bus works fine
+    expect(globalEventBusEmitSpy.callCount).equal(6);
+    expect(globalEventBusEmitSpy.calledWith('volumecontroller-hide')).equal(true);
+    expect(globalEventBusEmitSpy.calledWith('progressbar-hide')).equal(true);
+    expect(globalEventBusEmitSpy.calledWith('timecode-hide')).equal(true);
+    expect(globalEventBusEmitSpy.calledWith('sub-ctrl-hide')).equal(true);
+    expect(globalEventBusEmitSpy.calledWith('titlebar-hide')).equal(true);
+
+    expect(wrapper.vm.cursorShow).equal(false);
+    globalEventBusEmitSpy.restore();
+  });
+
+  it('Im so DOPE', () => {
+    const wrapper = shallowMount(PlayingView, ({ store, localVue }));
+    const stub = sinon.stub(wrapper.vm.$bus, '$on');
+    stub.yields();
+    const spy = sinon.spy(wrapper.vm, 'hideAllWidgets');
+    stub('hideAllWidgets', spy);
+    expect(spy.calledOnce).equal(true);
+    stub.restore();
+    spy.restore();
+  });
+});
 describe('PlayingView.vue.lyc', () => {
   let store;
   let timer; //eslint-disable-line


### PR DESCRIPTION
fixed the bug mouse up being missed and add click validator to agree click with quick and small movement to be click rather than drag and for mac when user doesn't focus on window it will not show the widgets when mouse enter