### PR TITLE
Bug windows linebreak style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force all files' linebreak style to be UNIX's LF style
+* text=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Force all files' linebreak style to be UNIX's LF style
-* text=false
+* text=auto eol=lf


### PR DESCRIPTION
- Add .gitattributes file
- Add eol=lf to force the use of UNIX linebreak style.