### PR TITLE
fix(openFile): fix open file with special characters bug

### DIFF
--- a/src/renderer/components/LandingView.vue
+++ b/src/renderer/components/LandingView.vue
@@ -283,7 +283,7 @@ body {
     z-index: 4;
   }
   .item-name {
-    width: 500px;
+    width: 70%;
     word-break: break-all;
     font-size: 30px;
     font-weight: bold;

--- a/src/renderer/components/LandingView/Playlist.vue
+++ b/src/renderer/components/LandingView/Playlist.vue
@@ -47,7 +47,6 @@
 
 <script>
 import path from 'path';
-import { filePathToUrl } from '@/helpers/path';
 
 export default {
   name: 'playlist',
@@ -145,7 +144,6 @@ export default {
   },
   methods: {
     open(link) {
-      console.log(this.windowWidth);
       if (this.showingPopupDialog) {
         // skip if there is already a popup dialog
         return;
@@ -173,7 +171,7 @@ export default {
       }, (item) => {
         self.showingPopupDialog = false;
         if (item) {
-          self.openFile(filePathToUrl(item[0]));
+          self.openFile(item[0]);
         }
       });
     },

--- a/src/renderer/components/PlayingView/BaseVideoPlayer.vue
+++ b/src/renderer/components/PlayingView/BaseVideoPlayer.vue
@@ -21,6 +21,7 @@ export default {
         const fileSrcRegexes = [
           RegExp('^(http|https)://'),
           RegExp('^file:///?'),
+          RegExp(/^[a-zA-Z]:\/(((?![<>:"//|?*]).)+((?<![ .])\/)?)*$/),
         ];
         return value.length > 0 && fileSrcRegexes.some(rule => rule.test(value));
       },

--- a/src/renderer/components/PlayingView/ThePreviewThumbnail.vue
+++ b/src/renderer/components/PlayingView/ThePreviewThumbnail.vue
@@ -84,7 +84,6 @@ export default {
       this.mountImage = false;
       this.generatedIndex = 0;
       this.currentIndex = 0;
-      console.log(this.$store.state.PlaybackState.OriginSrcOfVideo);
       this.quickHash = this.mediaQuickHash(this.$store.state.PlaybackState.OriginSrcOfVideo);
       this.retrieveThumbnailInfo(this.quickHash).then(this.updateThumbnailData);
     },

--- a/src/renderer/components/PlayingView/ThePreviewThumbnail.vue
+++ b/src/renderer/components/PlayingView/ThePreviewThumbnail.vue
@@ -78,14 +78,14 @@ export default {
     };
   },
   watch: {
-    src(newValue) {
+    src() {
       // Reload video and image components
       this.mountVideo = false;
       this.mountImage = false;
       this.generatedIndex = 0;
       this.currentIndex = 0;
-      newValue = decodeURI(newValue.replace(/%23/g, '#').replace(/%3F/g, '?'));
-      this.updateMediaQuickHash(newValue);
+      console.log(this.$store.state.PlaybackState.OriginSrcOfVideo);
+      this.quickHash = this.mediaQuickHash(this.$store.state.PlaybackState.OriginSrcOfVideo);
       this.retrieveThumbnailInfo(this.quickHash).then(this.updateThumbnailData);
     },
     currentTime(newValue) {
@@ -101,20 +101,6 @@ export default {
     },
   },
   methods: {
-    updateMediaQuickHash(src) {
-      const regexes = {
-        file: new RegExp('^file:///?'),
-        http: new RegExp('^(http|https)://'),
-      };
-
-      let filePath = src;
-      Object.keys(regexes).forEach((fileType) => {
-        if (regexes[fileType].test(src)) {
-          filePath = src.replace(regexes[fileType], '');
-        }
-      });
-      this.quickHash = this.mediaQuickHash(filePath);
-    },
     updateThumbnailInfo(event) {
       this.autoGenerationIndex = event.index;
       this.generationInterval = event.interval;
@@ -194,7 +180,7 @@ export default {
       /* eslint-disable newline-per-chained-call */
     });
     idb.open(INFO_DATABASE_NAME).then((db) => {
-      this.updateMediaQuickHash(decodeURI(this.src.toString().replace(/%23/g, '#').replace(/%3F/g, '?')));
+      this.quickHash = this.mediaQuickHash(this.$store.state.PlaybackState.OriginSrcOfVideo);
       const obejctStoreName = THUMBNAIL_OBJECT_STORE_NAME;
       if (!db.objectStoreNames.contains(obejctStoreName)) {
         console.log('[IndexedDB]: Initial preview thumbnail info objectStore.');

--- a/src/renderer/components/PlayingView/ThumbnailVideoPlayer.vue
+++ b/src/renderer/components/PlayingView/ThumbnailVideoPlayer.vue
@@ -101,8 +101,8 @@ export default {
       let result = '';
       const fileSrcRegexes = {
         http: RegExp('^(http|https)://'),
-        file_notwindows: RegExp('^file://'),
-        file_windows: RegExp(/^[a-zA-Z]:\/(((?![<>:"//|?*]).)+((?<![ .])\/)?)*$/),
+        notWindowsFile: RegExp('^file://'),
+        windowsFile: RegExp(/^[a-zA-Z]:\/(((?![<>:"//|?*]).)+((?<![ .])\/)?)*$/),
       };
       if (typeof src === 'string') {
         Object.keys(fileSrcRegexes).forEach((filetype) => {

--- a/src/renderer/components/PlayingView/ThumbnailVideoPlayer.vue
+++ b/src/renderer/components/PlayingView/ThumbnailVideoPlayer.vue
@@ -100,17 +100,15 @@ export default {
     videoSrcValidator(src) {
       const fileSrcRegexes = {
         http: RegExp('^(http|https)://'),
-        file: RegExp('^file:///?'),
+        file_notwindows: RegExp('^file:///?'),
+        file_windows: RegExp(/^[a-zA-Z]:\/(((?![<>:"//|?*]).)+((?<![ .])\/)?)*$/),
       };
       if (typeof src === 'string') {
-        if (fileSrcRegexes.http.test(src)) {
-          return 'http';
-        }
-        if (fileSrcRegexes.file.test(src)) {
-          return 'file';
-        }
+        Object.keys(fileSrcRegexes).forEach((filetype) => {
+          if (fileSrcRegexes[filetype].test(src)) return filetype;
+          return null;
+        });
       }
-      throw new TypeError('invalid src value.');
     },
     // Data regenerators
     updateGenerationParameters() {

--- a/src/renderer/components/PlayingView/ThumbnailVideoPlayer.vue
+++ b/src/renderer/components/PlayingView/ThumbnailVideoPlayer.vue
@@ -98,17 +98,18 @@ export default {
   methods: {
     // Data validators
     videoSrcValidator(src) {
+      let result = '';
       const fileSrcRegexes = {
         http: RegExp('^(http|https)://'),
-        file_notwindows: RegExp('^file:///?'),
+        file_notwindows: RegExp('^file://'),
         file_windows: RegExp(/^[a-zA-Z]:\/(((?![<>:"//|?*]).)+((?<![ .])\/)?)*$/),
       };
       if (typeof src === 'string') {
         Object.keys(fileSrcRegexes).forEach((filetype) => {
-          if (fileSrcRegexes[filetype].test(src)) return filetype;
-          return null;
+          if (fileSrcRegexes[filetype].test(src)) result = filetype;
         });
       }
+      return result;
     },
     // Data regenerators
     updateGenerationParameters() {
@@ -206,6 +207,7 @@ export default {
     updateVideoInfo(outerThumbnailInfo) {
       const { videoSrc } = outerThumbnailInfo;
       if (this.videoSrcValidator(videoSrc)) {
+        console.log(videoSrc);
         this.videoSrc = videoSrc;
         if (!outerThumbnailInfo.newVideo) {
           this.screenWidth = outerThumbnailInfo.screenWidth;

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -5,7 +5,6 @@
       ref="videoCanvas"
       :defaultEvents="['play', 'pause', 'playing', 'canplay', 'timeupdate', 'loadedmetadata', 'durationchange']"
       :styleObject="{objectFit: 'contain', width: '100%', height: '100%'}"
-
       @play="onPlay"
       @pause="onPause"
       @playing="onPlaying"
@@ -250,7 +249,7 @@ export default {
       this.$_saveScreenshot();
       asyncStorage.get('recent-played')
         .then(async (data) => {
-          const val = await this.infoDB().get('recent-played', 'path', decodeURI(oldVal.replace(/%23/g, '#').replace(/%3F/g, '?')));
+          const val = await this.infoDB().get('recent-played', 'path', oldVal);
           if (val && data) {
             const mergedData = Object.assign(val, data);
             this.infoDB().add('recent-played', mergedData);

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -238,9 +238,12 @@ export default {
     currentTime() {
       return this.$store.state.PlaybackState.CurrentTime;
     },
+    originSrcOfVideo() {
+      return this.$store.state.PlaybackState.OriginSrcOfVideo;
+    },
   },
   watch: {
-    src(val, oldVal) {
+    originSrcOfVideo(val, oldVal) {
       const window = this.$electron.remote.getCurrentWindow();
       this.windowRectangleOld.x = window.getBounds().x;
       this.windowRectangleOld.y = window.getBounds().y;
@@ -250,8 +253,10 @@ export default {
       asyncStorage.get('recent-played')
         .then(async (data) => {
           const val = await this.infoDB().get('recent-played', 'path', oldVal);
+          console.log(oldVal, val, data);
           if (val && data) {
             const mergedData = Object.assign(val, data);
+            console.log(mergedData);
             this.infoDB().add('recent-played', mergedData);
           }
         });

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -253,10 +253,8 @@ export default {
       asyncStorage.get('recent-played')
         .then(async (data) => {
           const val = await this.infoDB().get('recent-played', 'path', oldVal);
-          console.log(oldVal, val, data);
           if (val && data) {
             const mergedData = Object.assign(val, data);
-            console.log(mergedData);
             this.infoDB().add('recent-played', mergedData);
           }
         });

--- a/src/renderer/helpers/index.js
+++ b/src/renderer/helpers/index.js
@@ -2,7 +2,6 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 import InfoDB from '@/helpers/infoDB';
-import { filePathToUrl } from '@/helpers/path';
 import Sagi from './sagi';
 
 export default {
@@ -65,6 +64,7 @@ export default {
     },
     openFile(path) {
       const originPath = path;
+      const convertedPath = encodeURIComponent(originPath).replace(/%3A/g, ':').replace(/(%5C)|(%2F)/g, '/');
       this.infoDB().get('recent-played', this.mediaQuickHash(originPath))
         .then((value) => {
           if (value) {
@@ -79,7 +79,10 @@ export default {
           }
           this.$bus.$emit('new-file-open');
         });
-      this.$store.commit('SrcOfVideo', filePathToUrl(originPath));
+      this.$store.commit(
+        'SrcOfVideo',
+        process.platform === 'win32' ? convertedPath : `file://${convertedPath}`,
+      );
       this.$bus.$emit('new-video-opened');
       this.$router.push({
         name: 'playing-view',

--- a/src/renderer/helpers/index.js
+++ b/src/renderer/helpers/index.js
@@ -83,6 +83,7 @@ export default {
         'SrcOfVideo',
         process.platform === 'win32' ? convertedPath : `file://${convertedPath}`,
       );
+      this.$store.commit('OriginSrcOfVideo', originPath);
       this.$bus.$emit('new-video-opened');
       this.$router.push({
         name: 'playing-view',

--- a/src/renderer/helpers/path.js
+++ b/src/renderer/helpers/path.js
@@ -10,7 +10,7 @@ export function filePathToUrl(filePath) {
   if (!fileUrl.startsWith('/')) {
     fileUrl = `/${fileUrl}`;
   }
-  fileUrl = encodeURI(`file://${fileUrl}`);
+  fileUrl = encodeURI(`file://${fileUrl}`).replace(/#/g, '%23').replace(/[?]/g, '%3F');
   return fileUrl;
 }
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -450,7 +450,10 @@ new Vue({
         }
       }
       if (potentialVidPath) {
-        this.openFile(potentialVidPath);
+        this.openFile(potentialVidPath.replace(
+          process.platform === 'win32' ? /^file:\/\// : /^file:\/\/\//,
+          '',
+        ));
       }
       if (containsSubFiles) {
         this.$bus.$emit('add-subtitle', subtitleFiles);

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -11,7 +11,6 @@ import router from '@/router';
 import store from '@/store';
 import messages from '@/locales';
 import helpers from '@/helpers';
-import { filePathToUrl } from '@/helpers/path';
 import Path from 'path';
 
 if (!process.env.IS_WEB) Vue.use(require('vue-electron'));
@@ -56,8 +55,7 @@ new Vue({
                   }],
                 }, (file) => {
                   if (file !== undefined) {
-                    const path = filePathToUrl(file[0]);
-                    this.openFile(path);
+                    this.openFile(file[0]);
                   }
                 });
               },

--- a/src/renderer/store/modules/PlaybackState.js
+++ b/src/renderer/store/modules/PlaybackState.js
@@ -5,6 +5,7 @@ const state = {
   Duration: NaN,
   Volume: 0.2,
   SrcOfVideo: '',
+  OriginSrcOfVideo: '',
   PlaybackRate: 1.0,
   SubtitleNameArr: [],
   isPlaying: false,
@@ -23,6 +24,9 @@ const mutations = {
   },
   SrcOfVideo(state, t) {
     state.SrcOfVideo = t;
+  },
+  OriginSrcOfVideo(state, t) {
+    state.OriginSrcOfVideo = t;
   },
   CurrentTime(state, t) {
     state.CurrentTime = t;

--- a/test/unit/specs/updater/VideoCanvas.spec.js
+++ b/test/unit/specs/updater/VideoCanvas.spec.js
@@ -62,7 +62,7 @@ describe('VideoCanvas.vue', () => {
     spy.restore();
   });
 
-  it('watch src work fine', () => {
+  it('watch OriginSrcOfVideo work fine', () => {
     const stub = sinon.stub(wrapper.vm.$electron.remote, 'getCurrentWindow').callsFake(() => ({
       getBounds() {
         return {
@@ -73,7 +73,9 @@ describe('VideoCanvas.vue', () => {
         };
       },
     }));
-    wrapper.vm.src = 'abc';
+
+    wrapper.vm.$store.commit('OriginSrcOfVideo', 'abc');
+
     expect(wrapper.vm.windowRectangleOld.x).equal(10);
     expect(wrapper.vm.windowRectangleOld.y).equal(10);
     expect(wrapper.vm.windowRectangleOld.height).equal(10);


### PR DESCRIPTION
## Refactor `openFile` helper method with @Pat1enceLos .

- `openFile` now only accept raw file path without `file://` prefix, like `D:\Videos\test.mkv` and `/User/Test/Documents/test.mkv`.
- Chrome will automatically convert proper raw file path(without `#`, `?` and `\` special characters) to usable URLs. So before commit it to Vuex, special characters must be replaced with `%`-prefixed ASCII code([URL Standard - Percent-encoded bytes](https://url.spec.whatwg.org/#percent-encoded-bytes)).
- `encodeURIComponent` handle CJK characters.

## Add `OriginSrcOfVideo` to Vuex PlaybackState

- Raw video path is necessary when it comes to generating `mediaQuickHash` and some other stuff.
- Instead of converting URL to raw video path, add `OriginSrcOfVideo` will make our lives easier.

## Solved Problems

- Open files with special characters(#, ?, %, whitespace)
- Open files with CJK characters

## Remaining Problems

- Open files with `/` is impossible.