### PR TITLE
feat(videocanvas): new logic about window size and pos

### DIFF
--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -31,7 +31,6 @@ export default {
   },
   data() {
     return {
-      windowRectangleOld: {},
       videoExisted: false,
       shownTextTrack: false,
       newWidthOfWindow: 0,

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -114,14 +114,14 @@ export default {
     },
     $_controlWindowSize() {
       const currentWindow = this.$electron.remote.getCurrentWindow();
+      const landingViewRectangle = currentWindow.getBounds();
       const [windowX, windowY] = currentWindow.getPosition();
       const windowPosition = { x: windowX, y: windowY };
+
       const allDisplay = this.$electron.screen.getAllDisplays();
       const currentDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);
-      console.log(allDisplay);
-      console.log(currentDisplay);
-      const windowXY = this.calcNewWindowXY(currentDisplay);
-      console.log(windowXY);
+
+      const windowXY = this.calcNewWindowXY(currentDisplay, landingViewRectangle);
 
       currentWindow.setSize(
         parseInt(this.newWidthOfWindow, 10),
@@ -143,8 +143,9 @@ export default {
     },
     $_calculateWindowSizeAtTheFirstTime() {
       const currentWindow = this.$electron.remote.getCurrentWindow();
-      const cursor = this.$electron.screen.getCursorScreenPoint();
-      const currentScreen = this.$electron.screen.getDisplayNearestPoint(cursor);
+      const [windowX, windowY] = currentWindow.getPosition();
+      const windowPosition = { x: windowX, y: windowY };
+      const currentScreen = this.$electron.screen.getDisplayNearestPoint(windowPosition);
       const { width: screenWidth, height: screenHeight } = currentScreen.workAreaSize;
       const [minWidth, minHeight] = currentWindow.getMinimumSize();
       const screenRatio = screenWidth / screenHeight;
@@ -227,9 +228,7 @@ export default {
       syncStorage.setSync('recent-played', data);
     },
     // responsible for calculating window position and size relative to LandingView's Center
-    calcNewWindowXY(currentDisplay) {
-      const window = this.$electron.remote.getCurrentWindow();
-      const landingViewRectangle = window.getBounds();
+    calcNewWindowXY(currentDisplay, landingViewRectangle) {
       let x = landingViewRectangle.x + (landingViewRectangle.width / 2);
       let y = landingViewRectangle.y + (landingViewRectangle.height / 2);
       x = Math.round(x - (this.newWidthOfWindow / 2));

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -127,16 +127,10 @@ export default {
         parseInt(this.newWidthOfWindow, 10),
         parseInt(this.newHeightOfWindow, 10),
       );
-      // currentWindow.setPosition(
-      //   windowXY.windowX,
-      //   windowXY.windowY,
-      // );
-      // currentWindow.setBounds({
-      //   x: windowXY.windowX,
-      //   y: windowXY.windowY,
-      //   width: parseInt(this.newWidthOfWindow, 10),
-      //   height: parseInt(this.newHeightOfWindow, 10),
-      // });
+      currentWindow.setPosition(
+        windowXY.windowX,
+        windowXY.windowY,
+      );
       currentWindow.setAspectRatio(this.newWidthOfWindow / this.newHeightOfWindow);
     },
     $_controlWindowSizeAtNewVideo() {
@@ -232,27 +226,32 @@ export default {
       };
       syncStorage.setSync('recent-played', data);
     },
-    // responsible for calculating window position and size from LandingView's Center
-    calcNewWindowXY(display) {
+    // responsible for calculating window position and size relative to LandingView's Center
+    calcNewWindowXY(currentDisplay) {
       const window = this.$electron.remote.getCurrentWindow();
       const landingViewRectangle = window.getBounds();
-      // (x, y) is the center of the landingview window
       let x = landingViewRectangle.x + (landingViewRectangle.width / 2);
       let y = landingViewRectangle.y + (landingViewRectangle.height / 2);
-      // (x, y) is now the upper-left of the new window
       x = Math.round(x - (this.newWidthOfWindow / 2));
       y = Math.round(y - (this.newHeightOfWindow / 2));
 
-      const currentScreen = this.$electron.screen.getPrimaryDisplay();
-      const { width: screenWidth, height: screenHeight } = currentScreen.workAreaSize;
+      const {
+        width: displayWidth,
+        height: displayHeight,
+        x: displayX, // the x axis of display's upper-left
+        y: displayY, // the y axis of display's upper-left
+      } = currentDisplay.workArea;
 
-      const left = x + this.newWidthOfWindow; // the x axis of window's left side
-      if (screenWidth - left < 0) {
-        x = Math.round(screenWidth - this.newWidthOfWindow);
+      if (x < displayX) x = displayX;
+      if (y < displayY) y = displayY;
+
+      const right = x + this.newWidthOfWindow; // the x axis of window's right side
+      if (displayWidth - right < displayX) {
+        x = Math.round(displayWidth - this.newWidthOfWindow);
       }
       const bottom = y + this.newHeightOfWindow; // the y axis of window's bottom side
-      if (screenHeight - bottom < 0) {
-        y = Math.round(screenHeight - this.newHeightOfWindow);
+      if (bottom > displayY + displayHeight) {
+        y = Math.round((displayY + displayHeight) - this.newHeightOfWindow);
       }
       return { windowX: x, windowY: y };
     },

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -133,7 +133,7 @@ export default {
     },
     $_controlWindowSizeAtNewVideo() {
       const currentWindow = this.$electron.remote.getCurrentWindow();
-      console.log(this.newWidthOfWindow, this.newHeightOfWindow);
+
       const [windowX, windowY] = currentWindow.getPosition();
       const windowPosition = { x: windowX, y: windowY };
       const currentDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -117,7 +117,6 @@ export default {
       const [windowX, windowY] = currentWindow.getPosition();
       const windowPosition = { x: windowX, y: windowY };
 
-      const allDisplay = this.$electron.screen.getAllDisplays();
       const currentDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);
 
       const windowXY = this.calcNewWindowXY(currentDisplay, landingViewRectangle);

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -119,10 +119,10 @@ export default {
       const [windowX, windowY] = currentWindow.getPosition();
       const windowPosition = { x: windowX, y: windowY };
       const allDisplay = this.$electron.screen.getAllDisplays();
-      const nearestDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);
+      const currentDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);
       console.log(allDisplay);
-      console.log(nearestDisplay);
-      const windowXY = this.calcNewWindowXY(nearestDisplay);
+      console.log(currentDisplay);
+      const windowXY = this.calcNewWindowXY(currentDisplay);
       console.log(windowXY);
 
       currentWindow.setSize(
@@ -235,15 +235,15 @@ export default {
       syncStorage.setSync('recent-played', data);
     },
     // responsible for calculating window position and size from LandingView's Center
-    calcNewWindowXY() {
+    calcNewWindowXY(display) {
       const window = this.$electron.remote.getCurrentWindow();
       const landingViewRectangle = window.getBounds();
+      // (x, y) is the center of the landingview window
       let x = landingViewRectangle.x + (landingViewRectangle.width / 2);
       let y = landingViewRectangle.y + (landingViewRectangle.height / 2);
+      // (x, y) is now the upper-left of the new window
       x = Math.round(x - (this.newWidthOfWindow / 2));
       y = Math.round(y - (this.newHeightOfWindow / 2));
-      if (x < 0) x = 0;
-      if (y < 0) y = 0;
 
       const currentScreen = this.$electron.screen.getPrimaryDisplay();
       const { width: screenWidth, height: screenHeight } = currentScreen.workAreaSize;

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -243,8 +243,8 @@ export default {
       if (y < displayY) y = displayY;
 
       const right = x + this.newWidthOfWindow; // the x axis of window's right side
-      if (displayWidth - right < displayX) {
-        x = Math.round(displayWidth - this.newWidthOfWindow);
+      if (right > displayX + displayWidth) {
+        x = Math.round((displayX + displayWidth) - this.newWidthOfWindow);
       }
       const bottom = y + this.newHeightOfWindow; // the y axis of window's bottom side
       if (bottom > displayY + displayHeight) {

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -114,9 +114,9 @@ export default {
     $_controlWindowSize() {
       const currentWindow = this.$electron.remote.getCurrentWindow();
       const landingViewRectangle = currentWindow.getBounds();
+
       const [windowX, windowY] = currentWindow.getPosition();
       const windowPosition = { x: windowX, y: windowY };
-
       const currentDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);
 
       const windowXY = this.calcNewWindowXY(currentDisplay, landingViewRectangle);
@@ -133,10 +133,18 @@ export default {
     },
     $_controlWindowSizeAtNewVideo() {
       const currentWindow = this.$electron.remote.getCurrentWindow();
+      console.log(this.newWidthOfWindow, this.newHeightOfWindow);
+      const [windowX, windowY] = currentWindow.getPosition();
+      const windowPosition = { x: windowX, y: windowY };
+      const currentDisplay = this.$electron.screen.getDisplayNearestPoint(windowPosition);
+
+      const windowXY = this.avoidBeyondDisplayBorder(currentDisplay, windowX, windowY);
+
       currentWindow.setSize(
         parseInt(this.newWidthOfWindow, 10),
         parseInt(this.newHeightOfWindow, 10),
       );
+      currentWindow.setPosition(windowXY.windowX, windowXY.windowY);
       currentWindow.setAspectRatio(this.newWidthOfWindow / this.newHeightOfWindow);
     },
     $_calculateWindowSizeAtTheFirstTime() {
@@ -232,12 +240,16 @@ export default {
       x = Math.round(x - (this.newWidthOfWindow / 2));
       y = Math.round(y - (this.newHeightOfWindow / 2));
 
+      return this.avoidBeyondDisplayBorder(currentDisplay, x, y);
+    },
+    // if the given (x, y) beyond the border of the given display, then adjust the x, y
+    avoidBeyondDisplayBorder(display, x, y) {
       const {
         width: displayWidth,
         height: displayHeight,
         x: displayX, // the x axis of display's upper-left
         y: displayY, // the y axis of display's upper-left
-      } = currentDisplay.workArea;
+      } = display.workArea;
 
       if (x < displayX) x = displayX;
       if (y < displayY) y = displayY;

--- a/test/unit/specs/updater/VideoCanvas.spec.js
+++ b/test/unit/specs/updater/VideoCanvas.spec.js
@@ -34,7 +34,6 @@ describe('VideoCanvas.vue', () => {
   });
 
   it('should load correct data', () => {
-    expect(wrapper.vm.windowRectangleOld).to.be.an('object');
     expect(wrapper.vm.videoExisted).equal(false);
     expect(wrapper.vm.shownTextTrack).equal(false);
     expect(wrapper.vm.newWidthOfWindow).equal(0);
@@ -53,13 +52,99 @@ describe('VideoCanvas.vue', () => {
     expect(store.state.PlaybackState.Volume).equal(1);
   });
 
-  it('calcNewWindowXY method work fine if no windowRectangleOld exist', () => {
-    wrapper.vm.windowRectangleOld = {};
-    const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
-    wrapper.vm.calcNewWindowXY();
-    expect(spy.called).equal(true);
-    expect(spy.returnValues[0]).deep.equal({ windowX: 0, windowY: 0 });
-    spy.restore();
+  describe('calcNewWindowXY method', () => {
+    it('landingview is on the upper-left', () => {
+      const currentDisplay = {
+        workArea: {
+          width: 1920,
+          height: 1080,
+          x: 0,
+          y: 0,
+        },
+      };
+      const landingViewRectangle = {
+        x: 20,
+        y: 20,
+        width: 500,
+        height: 500,
+      };
+      wrapper.vm.newHeightOfWindow = 1080;
+      wrapper.vm.newWidthOfWindow = 1920;
+      const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
+      wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
+      expect(spy.called).equal(true);
+      expect(spy.returnValues[0]).deep.equal({ windowX: 0, windowY: 0 });
+      spy.restore();
+    });
+    it('landingview is on the upper-right', () => {
+      const currentDisplay = {
+        workArea: {
+          width: 1920,
+          height: 1080,
+          x: 0,
+          y: 0,
+        },
+      };
+      const landingViewRectangle = {
+        x: 1800,
+        y: 20,
+        width: 500,
+        height: 500,
+      };
+      wrapper.vm.newHeightOfWindow = 1080;
+      wrapper.vm.newWidthOfWindow = 1920;
+      const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
+      wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
+      expect(spy.called).equal(true);
+      expect(spy.returnValues[0]).deep.equal({ windowX: 0, windowY: 0 });
+      spy.restore();
+    });
+    it('landingview is on the bottom-left', () => {
+      const currentDisplay = {
+        workArea: {
+          width: 1920,
+          height: 1080,
+          x: 0,
+          y: 0,
+        },
+      };
+      const landingViewRectangle = {
+        x: 20,
+        y: 1800,
+        width: 500,
+        height: 500,
+      };
+      wrapper.vm.newHeightOfWindow = 1080;
+      wrapper.vm.newWidthOfWindow = 1920;
+      const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
+      wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
+      expect(spy.called).equal(true);
+      expect(spy.returnValues[0]).deep.equal({ windowX: 0, windowY: 0 });
+      spy.restore();
+    });
+    it('landingview is on the bottom-left', () => {
+      const currentDisplay = {
+        workArea: {
+          width: 1920,
+          height: 1080,
+          x: 0,
+          y: 0,
+        },
+      };
+      const landingViewRectangle = {
+        x: 1800,
+        y: 1800,
+        width: 500,
+        height: 500,
+      };
+      wrapper.vm.newHeightOfWindow = 1080;
+      wrapper.vm.newWidthOfWindow = 1920;
+      const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
+      wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
+      expect(spy.called).equal(true);
+      expect(spy.returnValues[0]).deep.equal({ windowX: 0, windowY: 0 });
+      spy.restore();
+    });
   });
 
   it('watch OriginSrcOfVideo work fine', () => {
@@ -75,27 +160,7 @@ describe('VideoCanvas.vue', () => {
     }));
 
     wrapper.vm.$store.commit('OriginSrcOfVideo', 'abc');
-
-    expect(wrapper.vm.windowRectangleOld.x).equal(10);
-    expect(wrapper.vm.windowRectangleOld.y).equal(10);
-    expect(wrapper.vm.windowRectangleOld.height).equal(10);
-    expect(wrapper.vm.windowRectangleOld.width).equal(10);
     stub.restore();
-  });
-
-  it('calcNewWindowXY method work fine if windowRectangelOld exist', () => {
-    wrapper.vm.windowRectangleOld = {
-      x: 10,
-      y: 10,
-      width: 100,
-      height: 100,
-    };
-    wrapper.vm.newHeightOfWindow = wrapper.vm.newWidthOfWindow = 100;
-    const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
-    wrapper.vm.calcNewWindowXY();
-    expect(spy.called).equal(true);
-    expect(spy.returnValues[0]).deep.equal({ windowX: 10, windowY: 10 });
-    spy.restore();
   });
 
   it('onMetaLoaded method work fine if video not exist', () => {

--- a/test/unit/specs/updater/VideoCanvas.spec.js
+++ b/test/unit/specs/updater/VideoCanvas.spec.js
@@ -53,8 +53,9 @@ describe('VideoCanvas.vue', () => {
   });
 
   describe('calcNewWindowXY method', () => {
-    it('landingview is on the upper-left', () => {
-      const currentDisplay = {
+    let currentDisplay;
+    beforeEach(() => {
+      currentDisplay = {
         workArea: {
           width: 1920,
           height: 1080,
@@ -62,14 +63,16 @@ describe('VideoCanvas.vue', () => {
           y: 0,
         },
       };
+      wrapper.vm.newHeightOfWindow = 1080;
+      wrapper.vm.newWidthOfWindow = 1920;
+    });
+    it('landingview is on the upper-left', () => {
       const landingViewRectangle = {
         x: 20,
         y: 20,
         width: 500,
         height: 500,
       };
-      wrapper.vm.newHeightOfWindow = 1080;
-      wrapper.vm.newWidthOfWindow = 1920;
       const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
       wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
       expect(spy.called).equal(true);
@@ -77,22 +80,12 @@ describe('VideoCanvas.vue', () => {
       spy.restore();
     });
     it('landingview is on the upper-right', () => {
-      const currentDisplay = {
-        workArea: {
-          width: 1920,
-          height: 1080,
-          x: 0,
-          y: 0,
-        },
-      };
       const landingViewRectangle = {
         x: 1800,
         y: 20,
         width: 500,
         height: 500,
       };
-      wrapper.vm.newHeightOfWindow = 1080;
-      wrapper.vm.newWidthOfWindow = 1920;
       const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
       wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
       expect(spy.called).equal(true);
@@ -100,22 +93,12 @@ describe('VideoCanvas.vue', () => {
       spy.restore();
     });
     it('landingview is on the bottom-left', () => {
-      const currentDisplay = {
-        workArea: {
-          width: 1920,
-          height: 1080,
-          x: 0,
-          y: 0,
-        },
-      };
       const landingViewRectangle = {
         x: 20,
         y: 1800,
         width: 500,
         height: 500,
       };
-      wrapper.vm.newHeightOfWindow = 1080;
-      wrapper.vm.newWidthOfWindow = 1920;
       const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
       wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
       expect(spy.called).equal(true);
@@ -123,22 +106,12 @@ describe('VideoCanvas.vue', () => {
       spy.restore();
     });
     it('landingview is on the bottom-left', () => {
-      const currentDisplay = {
-        workArea: {
-          width: 1920,
-          height: 1080,
-          x: 0,
-          y: 0,
-        },
-      };
       const landingViewRectangle = {
         x: 1800,
         y: 1800,
         width: 500,
         height: 500,
       };
-      wrapper.vm.newHeightOfWindow = 1080;
-      wrapper.vm.newWidthOfWindow = 1920;
       const spy = sinon.spy(wrapper.vm, 'calcNewWindowXY');
       wrapper.vm.calcNewWindowXY(currentDisplay, landingViewRectangle);
       expect(spy.called).equal(true);
@@ -158,7 +131,6 @@ describe('VideoCanvas.vue', () => {
         };
       },
     }));
-
     wrapper.vm.$store.commit('OriginSrcOfVideo', 'abc');
     stub.restore();
   });
@@ -197,6 +169,9 @@ describe('VideoCanvas.vue', () => {
           getMinimumSize() {
             return [427, 240];
           },
+          getPosition() {
+            return [0, 0];
+          },
         }));
       });
       afterEach(() => {
@@ -231,6 +206,9 @@ describe('VideoCanvas.vue', () => {
         const windowStub = sinon.stub(wrapper.vm.$electron.remote, 'getCurrentWindow').callsFake(() => ({
           getMinimumSize() {
             return [427, 240];
+          },
+          getPosition() {
+            return [0, 0];
           },
         }));
         wrapper.vm.videoWidth = 450;


### PR DESCRIPTION
## New logic
- Window's position is based on landingview's center when first opening the video in the landingview
- When opening a new video in the playing view, window's size changed based on the upper-left corner of the window