### PR TITLE
Feature(window-title-bar): new feature for window maximize on mac OS

### DIFF
--- a/src/renderer/components/LandingView/Playlist.vue
+++ b/src/renderer/components/LandingView/Playlist.vue
@@ -128,7 +128,8 @@ export default {
     windowWidth(val) {
       this.itemWidth = (this.changeSize * val) / 100;
       this.itemHeight = (this.changeSize * val * 405) / 100 / 720;
-      document.querySelector('.item').style.transition = '';
+      // console.log(document.querySelector('.item'));
+      // document.querySelector('.item').style.transition = '';
     },
     showItemNum(val, oldval) {
       if (val > oldval) {

--- a/src/renderer/components/Titlebar.vue
+++ b/src/renderer/components/Titlebar.vue
@@ -274,9 +274,11 @@ export default {
   }
 }
 .titleBarDoubleClickHandle{
-  position: relative;
+  z-index: 3;
+  position: absolute;
   height:32px;
   width:100%;
+  background: transparent;
 }
 .darwin-titlebar {
   position: absolute;


### PR DESCRIPTION
开发任务：窗口最大化（非全屏）/ 恢复原始大小操作 完成
在titlebar加了双击事件监听，使用electron的api currentWindow.unmaximize()喝currentWindow.maximize();实现最大化和恢复原始大小
在原有监听handleMouseOver()和handleMouseOut()上增加了键盘输入监听来实现Option+鼠标hover切换图标的功能，并复用handleDoubleClick()来实现最大化和恢复原始大小功能