### PR TITLE
fix(playlist): fix some issues on playlist

### DIFF
--- a/src/renderer/components/PlayingView/PlaylistControl.vue
+++ b/src/renderer/components/PlayingView/PlaylistControl.vue
@@ -40,7 +40,7 @@ export default {
       switch (this.clicks) {
         case 1:
           this.$emit('update:showAttached', true);
-          this.$electron.ipcRenderer.send('callCurrentWindowMethod', 'setMinimumSize', [512, Math.floor(512 / this.videoRatio)]);
+          this.$electron.ipcRenderer.send('callCurrentWindowMethod', 'setMinimumSize', [512, Math.round(512 / this.videoRatio)]);
           break;
         case 2:
           this.$emit('update:showAttached', false);

--- a/src/renderer/components/PlayingView/PlaylistControl.vue
+++ b/src/renderer/components/PlayingView/PlaylistControl.vue
@@ -40,7 +40,7 @@ export default {
       switch (this.clicks) {
         case 1:
           this.$emit('update:showAttached', true);
-          this.$electron.ipcRenderer.send('callCurrentWindowMethod', 'setMinimumSize', [512, 512 / this.videoRatio]);
+          this.$electron.ipcRenderer.send('callCurrentWindowMethod', 'setMinimumSize', [512, Math.floor(512 / this.videoRatio)]);
           break;
         case 2:
           this.$emit('update:showAttached', false);

--- a/src/renderer/components/PlayingView/PlaylistControl.vue
+++ b/src/renderer/components/PlayingView/PlaylistControl.vue
@@ -25,6 +25,11 @@ export default {
       clicks: 0,
     };
   },
+  computed: {
+    videoRatio() {
+      return this.$store.getters.ratio;
+    },
+  },
   methods: {
     handleAnimation(anim) {
       this.anim = anim;
@@ -35,6 +40,7 @@ export default {
       switch (this.clicks) {
         case 1:
           this.$emit('update:showAttached', true);
+          this.$electron.ipcRenderer.send('callCurrentWindowMethod', 'setMinimumSize', [512, 512 / this.videoRatio]);
           break;
         case 2:
           this.$emit('update:showAttached', false);

--- a/src/renderer/components/PlayingView/RecentPlaylist.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylist.vue
@@ -243,7 +243,7 @@ export default {
       const A = 40; // playlist left margin
       const B = 15; // space between each playlist item
       const C = 60; // the space between last playlist item and right edge of the screen
-      if (this.winWidth > 512 && this.winWidth <= 1355) {
+      if (this.winWidth >= 512 && this.winWidth <= 1355) {
         width = ((((this.winWidth - A) - C) + B) / this.thumbnailNumber) - B;
       } else if (this.winWidth > 1355) {
         width = this.winWidth * (112 / 1355);
@@ -256,7 +256,7 @@ export default {
 <style lang="scss" scoped>
 .recent-playlist {
   width: 100%;
-  @media screen and (max-width: 512px) {
+  @media screen and (max-width: 511px) {
     display: none;
   }
   @media screen and (min-width: 512px) {

--- a/src/renderer/components/PlayingView/RecentPlaylist.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylist.vue
@@ -256,7 +256,7 @@ export default {
 <style lang="scss" scoped>
 .recent-playlist {
   width: 100%;
-  @media screen and (max-width: 511px) {
+  @media screen and (max-width: 510px) {
     display: none;
   }
   @media screen and (min-width: 512px) {

--- a/src/renderer/components/PlayingView/RecentPlaylist.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylist.vue
@@ -48,6 +48,7 @@
         :isPlaying="index === playingIndex"
         :winWidth="winWidth"
         :isShifting="shifting"
+        :transferedTime="transferedTime"
         :thumbnailWidth="thumbnailWidth"
         @mouseupItem="itemMouseup"
         @mouseoutItem="itemMouseout"
@@ -84,6 +85,7 @@ export default {
       backgroundDisplayState: this.displayState,
       mousePosition: [],
       canHoverItem: false,
+      transferedTime: 0,
     };
   },
   mounted() {
@@ -125,6 +127,7 @@ export default {
           this.shifting = false;
         }, 400);
       } else if (index !== this.playingIndex) {
+        this.transferedTime = this.roundedCurrentTime;
         this.openFile(this.playingList[index]);
         this.$store.dispatch(videoAction.PLAY_VIDEO);
       }

--- a/src/renderer/components/PlayingView/RecentPlaylistItem.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylistItem.vue
@@ -7,7 +7,7 @@
   :class="{ chosen: isChosen }"
   :style="{
     marginRight: sizeAdaption(15),
-    cursor: isPlaying ? '' : 'pointer',
+    cursor: isPlaying && isInRange ? '' : 'pointer',
     minWidth: `${thumbnailWidth}px`,
     minHeight: `${thumbnailHeight}px`,
   }">

--- a/src/renderer/components/PlayingView/RecentPlaylistItem.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylistItem.vue
@@ -120,6 +120,9 @@ export default {
     path: {
       type: String,
     },
+    transferedTime: {
+      type: Number,
+    },
   },
   data() {
     return {
@@ -171,9 +174,14 @@ export default {
     });
   },
   watch: {
-    originSrc() {
+    originSrc(val, oldVal) {
       this.infoDB().get('recent-played', 'path', this.path).then((val) => {
-        if (val && val.lastPlayedTime) this.lastPlayedTime = val.lastPlayedTime;
+        if (val && val.lastPlayedTime) {
+          this.lastPlayedTime = val.lastPlayedTime;
+        }
+        if (oldVal === this.path) {
+          val.lastPlayedTime = this.transferedTime;
+        }
         this.mediaInfo = Object.assign(this.mediaInfo, val);
       });
     },

--- a/src/renderer/components/PlayingView/TheVideoController.vue
+++ b/src/renderer/components/PlayingView/TheVideoController.vue
@@ -16,7 +16,7 @@
     :displayState="displayState['recent-playlist']"
     :mousemove="eventInfo.get('mousemove')"
     v-bind.sync="widgetsStatus['recent-playlist']"
-    @update:playlistcontrol-showattached="widgetsStatus['playlist-control'].showAttached = $event"/>
+    @update:playlistcontrol-showattached="updatePlaylistShowAttached"/>
     <div class="masking" v-hidden="displayState['the-progress-bar']"></div>
     <play-button :paused="paused" />
     <volume-indicator v-hidden="displayState['volume-indicator']"/>
@@ -177,6 +177,10 @@ export default {
     });
   },
   methods: {
+    updatePlaylistShowAttached(event) {
+      this.widgetsStatus['playlist-control'].showAttached = event;
+      this.$electron.ipcRenderer.send('callCurrentWindowMethod', 'setMinimumSize', [320, 180]);
+    },
     // UIManagers
     UIManager(timestamp) {
       if (!this.start) {


### PR DESCRIPTION
- 播放列表无法实施显示播放历史记录（进度和时间）
例如：播放列表里上一个播放的视频时间还是之前结束时候的记录 而不会被更新到最近一次播放结束的时间。比如 有个是视频播放到 11:23 我点了继续播放 播放到21:35 我点了其他视频，则刚刚那个视频的时间还是11:23 不会更新到21:35（缩略图和进度也不会更新），虽然再点回它，确是可以从21:35继续播放。
- 正在播放卡片，如果正好成为露出半个的翻页按钮，hover 时鼠标为小手。
- 在打开播放列表的前提下，缩放视频窗口当到达播放列表展示最小宽度时(512px)，就不允许用户再缩小窗比例。