### PR TITLE
feat(main.js): clean playback history manually

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -108,7 +108,7 @@ function registerMainWindowEvent() {
   function snapShot(videoPath, callback) {
     const imgPath = path.join(app.getPath('temp'), path.basename(videoPath, path.extname(videoPath)));
     const randomNumber = Math.round((Math.random() * 20) + 5);
-    const numberString = randomNumber < 9 ? `0${randomNumber}` : `${randomNumber}`;
+    const numberString = randomNumber < 10 ? `0${randomNumber}` : `${randomNumber}`;
     splayerx.snapshotVideo(videoPath, `${imgPath}.png`, `00:00:${numberString}`, (err) => {
       console.log(err, videoPath);
       callback(err, imgPath);

--- a/src/renderer/components/LandingView.vue
+++ b/src/renderer/components/LandingView.vue
@@ -131,6 +131,12 @@ export default {
           this.lastPlayedFile = data.slice(0, 9);
         });
       });
+    this.$bus.$on('clean-lastPlayedFile', () => {
+      this.lastPlayedFile = [];
+      this.langdingLogoAppear = true;
+      this.showShortcutImage = false;
+      this.infoDB().cleanData();
+    });
   },
   beforeDestroy() {
     window.onresize = null;

--- a/src/renderer/components/PlayingView/BaseVideoPlayer.vue
+++ b/src/renderer/components/PlayingView/BaseVideoPlayer.vue
@@ -190,7 +190,7 @@ export default {
       const basicInfo = [
         'src', 'crossOrigin', 'preload',
         'defaultPlaybackRate', 'autoplay',
-        'defaultMuted',
+        'defaultMuted', 'muted', 'volume',
       ];
       basicInfo.forEach((settingItem) => {
         videoElement[settingItem] = this[settingItem];

--- a/src/renderer/components/PlayingView/RecentPlaylistItem.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylistItem.vue
@@ -11,7 +11,7 @@
         <div class="img"
           v-if="!isPlaying && imageLoaded"
           :style="{
-            backgroundImage: `url('${imageSrc}')`,
+            backgroundImage: backgroundImage,
           }"/>
         <div class="blur"
           v-show="!isChosen && !isPlaying"/>
@@ -166,7 +166,7 @@ export default {
   mounted() {
     this.$electron.ipcRenderer.send('snapShot', this.path);
     this.$electron.ipcRenderer.once(`snapShot-${this.path}-reply`, (event, imgPath) => {
-      this.coverSrc = `${imgPath}.png`;
+      this.coverSrc = `file://${imgPath}.png`;
     });
     this.$electron.ipcRenderer.send('mediaInfo', this.path);
     this.$electron.ipcRenderer.once(`mediaInfo-${this.path}-reply`, (event, info) => {
@@ -187,6 +187,9 @@ export default {
   },
   computed: {
     ...mapGetters(['originSrc']),
+    backgroundImage() {
+      return `url(${this.imageSrc})`;
+    },
     imageSrc() {
       if (this.smallShortCut) {
         return this.smallShortCut;
@@ -194,7 +197,7 @@ export default {
       return this.coverSrc;
     },
     imageLoaded() {
-      return this.mediaInfo.smallShortCut || this.coverSrc !== '';
+      return this.smallShortCut || this.coverSrc !== '';
     },
     thumbnailHeight() {
       return this.thumbnailWidth / (112 / 63);

--- a/src/renderer/components/PlayingView/TheVideoController.vue
+++ b/src/renderer/components/PlayingView/TheVideoController.vue
@@ -103,13 +103,15 @@ export default {
       focusDelay: 500,
       listenedWidget: 'the-video-controller',
       progressBarHovering: false,
+      attachedShown: false,
     };
   },
   computed: {
     ...mapGetters(['muted', 'paused']),
     showAllWidgets() {
       return (!this.mouseStopMoving && !this.mouseLeftWindow) ||
-        (!this.mouseLeftWindow && this.onOtherWidget);
+        (!this.mouseLeftWindow && this.onOtherWidget) ||
+        this.attachedShown;
     },
     onOtherWidget() {
       return this.currentWidget !== this.$options.name;
@@ -329,6 +331,8 @@ export default {
           }
         }
       });
+      this.attachedShown = Object.keys(this.widgetsStatus)
+        .some(key => this.widgetsStatus[key].showAttached === true);
     },
     // Event listeners
     handleMousemove(event) {

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -70,8 +70,8 @@ export default {
     onMetaLoaded(event) {
       this.videoElement = event.target;
       this.videoConfigInitialize({
-        volume: 100,
-        muted: false,
+        volume: this.volume * 100,
+        muted: this.muted,
         rate: 1,
         duration: event.target.duration,
         currentTime: this.lastPlayedTime || 0,
@@ -251,6 +251,9 @@ export default {
     }),
   },
   watch: {
+    muted(val) {
+      console.log('muted', val);
+    },
     originSrc(val, oldVal) {
       this.coverFinded = false;
       this.saveScreenshot();

--- a/src/renderer/locales/lang/en.js
+++ b/src/renderer/locales/lang/en.js
@@ -6,6 +6,7 @@ export default {
       open: 'Open…',
       openURL: 'Open URL…',
       openRecent: 'Open Recent',
+      clearHistory: 'Clear Playback History',
       closeWindow: 'Close Window',
     },
     playback: {

--- a/src/renderer/locales/lang/zhCN.js
+++ b/src/renderer/locales/lang/zhCN.js
@@ -6,6 +6,7 @@ export default {
       open: '打开文件…',
       openURL: '打开URL…',
       openRecent: '最近播放',
+      clearHistory: '清空播放记录',
       closeWindow: '关闭',
     },
     playback: {

--- a/src/renderer/locales/lang/zhTW.js
+++ b/src/renderer/locales/lang/zhTW.js
@@ -6,6 +6,7 @@ export default {
       open: '打開文件…',
       openURL: '打開URL…',
       openRecent: '最近播放',
+      clearHistory: '清空播放紀錄',
       closeWindow: '關閉',
     },
     playback: {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -59,7 +59,7 @@ new Vue({
     };
   },
   computed: {
-    ...mapGetters(['muted', 'winWidth', 'chosenStyle', 'chosenSize', 'deleteVideoHistoryOnExit', 'privacyAgreement']),
+    ...mapGetters(['volume', 'muted', 'winWidth', 'chosenStyle', 'chosenSize', 'deleteVideoHistoryOnExit', 'privacyAgreement']),
   },
   created() {
     asyncStorage.get('subtitle-style').then((data) => {
@@ -88,6 +88,18 @@ new Vue({
     privacyAgreement(val) {
       if (this.menu) {
         this.menu.getMenuItemById('privacy').checked = val;
+      }
+    },
+    volume(val) {
+      if (val <= 0) {
+        this.menu.getMenuItemById('mute').checked = true;
+      } else {
+        this.menu.getMenuItemById('mute').checked = false;
+      }
+    },
+    muted(val) {
+      if (val) {
+        this.menu.getMenuItemById('mute').checked = val;
       }
     },
   },
@@ -191,9 +203,9 @@ new Vue({
               label: this.$t('msg.audio.mute'),
               type: 'checkbox',
               accelerator: 'M',
-              click: (menuItem) => {
+              id: 'mute',
+              click: () => {
                 this.$bus.$emit('toggle-muted');
-                menuItem.checked = this.muted;
               },
             },
             { label: this.$t('msg.audio.increaseAudioDelay'), enabled: false },
@@ -697,14 +709,17 @@ new Vue({
     });
     window.addEventListener('wheel', (e) => {
       if (!e.ctrlKey) {
-        const up = e.deltaY < 0;
+        const up = e.deltaY > 0;
         let isAdvanceColumeItem;
         const nodeList = document.querySelector('.advance-column-items').childNodes;
         for (let i = 0; i < nodeList.length; i += 1) {
           isAdvanceColumeItem = nodeList[i].contains(e.target);
         }
         if (!isAdvanceColumeItem) {
-          this.$store.dispatch(up ? videoActions.INCREASE_VOLUME : videoActions.DECREASE_VOLUME, 6);
+          this.$store.dispatch(
+            up ? videoActions.INCREASE_VOLUME : videoActions.DECREASE_VOLUME,
+            Math.abs(e.deltaY) * 0.2,
+          );
         }
       }
     });

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -148,6 +148,12 @@ new Vue({
               enabled: false,
             },
             {
+              label: this.$t('msg.file.clearHistory'),
+              click: () => {
+                this.$bus.$emit('clean-lastPlayedFile');
+              },
+            },
+            {
               label: this.$t('msg.file.closeWindow'),
               role: 'Close',
             },


### PR DESCRIPTION
## Menu
- clean playback history
## Video Player
- volume memorize feature
## BUGs:
- MAC 触控板调整音量方向是反的，且相应速度和幅度过大，需要识别鼠标滚轮和触控板操控的底层API
- 菜单面板、字幕面板通过点击事件唤出后，鼠标悬浮在面板外部，面板应一直停留，不会在3秒后消失
- 系统菜单静音勾选逻辑