### PR TITLE
fix(main/index.js, recentplaylistitem): fix bubble display bug and black-gradient overlaid by the image

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -226,6 +226,7 @@ function createWindow() {
 
   mainWindow.loadURL(winURL);
   mainWindow.on('closed', () => {
+    ipcMain.removeAllListeners();
     mainWindow = null;
   });
 

--- a/src/renderer/components/PlayingView/RecentPlaylist.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylist.vue
@@ -102,6 +102,7 @@ export default {
       this.$store.dispatch('RemovePlayingList', this.filePathNeedToDelete);
       this.filePathNeedToDelete = '';
     });
+    this.hoverIndex = this.playingIndex;
   },
   methods: {
     afterLeave() {

--- a/src/renderer/components/PlayingView/RecentPlaylistItem.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylistItem.vue
@@ -250,6 +250,7 @@ $border-radius: 3px;
       background-color: rgba(255,255,255,0.2);
     }
     .black-gradient {
+      position: absolute;
       border-radius: $border-radius;
       width: 100%;
       height: 100%;
@@ -265,8 +266,6 @@ $border-radius: 3px;
       bottom: 0;
       left: 0;
       right: 0;
-      width: 100%;
-      transform: translate(0px, 0px);
     }
     .content {
       position: absolute;


### PR DESCRIPTION
## BUG:
- 拖入非法视频文件，如PDF，错误气泡数量错误（会同时出现2-3个气泡）
- 播放列表黑色透明渐变层在缩略图下方
- 打开播放列表，卡片过程加载中，时间信息、文件名和集数均无法正常显示，hover 到某一卡片后恢复正常