### PR TITLE
fix(videocanvas, controlbuttons): animation bug

### DIFF
--- a/src/renderer/components/PlayingView/AdvanceControl.vue
+++ b/src/renderer/components/PlayingView/AdvanceControl.vue
@@ -135,6 +135,7 @@ export default {
       switch (this.clicks) {
         case 1:
           this.$emit('update:showAttached', true);
+          this.$emit('conflict-resolve', this.$options.name);
           break;
         case 2:
           this.$emit('update:showAttached', false);
@@ -147,6 +148,16 @@ export default {
     },
   },
   created() {
+    this.$bus.$on('isdragging-mouseup', () => {
+      if (this.showAttached) {
+        this.anim.playSegments([68, 73]);
+      }
+    });
+    this.$bus.$on('isdragging-mousedown', () => {
+      if (this.showAttached) {
+        this.anim.playSegments([37, 41], false);
+      }
+    });
     this.$bus.$on('change-menu-list', (changedLevel) => {
       this.menuList = changedLevel;
       this.$_fitMenuSize();

--- a/src/renderer/components/PlayingView/RecentPlaylist.vue
+++ b/src/renderer/components/PlayingView/RecentPlaylist.vue
@@ -114,6 +114,7 @@ export default {
     handleMouseup() {
       if (!this.isDragging) {
         this.$emit('update:playlistcontrol-showattached', false);
+        this.$emit('conflict-resolve', this.$options.name);
         this.$emit('update:isDragging', false);
       }
     },

--- a/src/renderer/components/PlayingView/SubtitleControl.vue
+++ b/src/renderer/components/PlayingView/SubtitleControl.vue
@@ -299,6 +299,7 @@ export default {
       switch (this.clicks) {
         case 1:
           this.$emit('update:showAttached', true);
+          this.$emit('conflict-resolve', this.$options.name);
           break;
         case 2:
           this.$emit('update:showAttached', false);
@@ -434,6 +435,16 @@ export default {
     },
   },
   created() {
+    this.$bus.$on('isdragging-mouseup', () => {
+      if (this.showAttached) {
+        this.anim.playSegments([79, 85]);
+      }
+    });
+    this.$bus.$on('isdragging-mousedown', () => {
+      if (this.showAttached) {
+        this.anim.playSegments([62, 64], false);
+      }
+    });
     this.$bus.$on('finish-loading', (type) => {
       const subType = ['ass', 'vtt', 'srt'];
       if (subType.includes(type)) {

--- a/src/renderer/components/PlayingView/VideoCanvas.vue
+++ b/src/renderer/components/PlayingView/VideoCanvas.vue
@@ -295,6 +295,8 @@ export default {
       if (e === this.duration && this.nextVideo) {
         this.openFile(this.nextVideo);
         return;
+      } else if (e === this.duration) {
+        this.pause();
       }
       // todo: use vuex get video element src
       const filePath = decodeURI(this.src);


### PR DESCRIPTION
## BUG:
- 播放列表上部阴影区域拖动后依然会触发关闭消失
- 字幕菜单、其他功能菜单展开后，在菜单外播放界面任意位置单击按住并拖动窗口，菜单按钮会变小，松开鼠标按钮不会恢复
- 视频播放到末尾结束后（单个视频或播放列表中最后一个视频），再次拖回进度的中间部分，点击屏幕时的响应有错误(看下面的视频)