### PR TITLE
style(titlebar): replace click event to mouseup event

### DIFF
--- a/src/renderer/components/Titlebar.vue
+++ b/src/renderer/components/Titlebar.vue
@@ -5,26 +5,26 @@
     @dblclick.stop="handleDbClick">
     <div class="win-icons" v-if="!isDarwin" v-fade-in="showTitleBar">
       <Icon class="title-button no-drag"
-        @click.native="handleMinimize"
+        @mouseup.native="handleMinimize"
         type="titleBarWinExitFull">
       </Icon>
       <Icon class="title-button no-drag"
-        @click.native="handleWinFull"
+        @mouseup.native="handleWinFull"
         v-show="middleButtonStatus === 'maximize'"
         type="titleBarWinFull">
       </Icon>
       <Icon class="title-button no-drag"
-        @click.native="handleRestore"
+        @mouseup.native="handleRestore"
         type="titleBarWinRestore"
         v-show="middleButtonStatus === 'restore'">
       </Icon>
       <Icon class="title-button no-drag"
-        @click.native="handleFullscreenExit"
+        @mouseup.native="handleFullscreenExit"
         v-show="middleButtonStatus === 'exit-fullscreen'"
         type="titleBarWinResize">
       </Icon>
       <Icon class="title-button no-drag"
-        @click.native="handleClose"
+        @mouseup.native="handleClose"
         type="titleBarWinClose">
       </Icon>
     </div>
@@ -36,24 +36,24 @@
       <Icon id="close" class="title-button no-drag"
             type="titleBarClose"
             :state="state"
-            @click.native="handleClose">
+            @mouseup.native="handleClose">
       </Icon>
       <Icon id="minimize" class="title-button no-drag"
             type="titleBarExitFull"
-            @click.native="handleMinimize"
+            @mouseup.native="handleMinimize"
             :class="{ disabled: middleButtonStatus === 'exit-fullscreen' }"
             :state="state"
             :isFullScreen="middleButtonStatus">
       </Icon>
       <Icon id="maximize" class="title-button no-drag"
             :type="itemType"
-            @click.native="handleMacFull"
+            @mouseup.native="handleMacFull"
             v-show="middleButtonStatus !== 'exit-fullscreen'"
             :state="state"
             :style="{ transform: itemType === this.itemTypeEnum.MAXSCREEN ? 'rotate(45deg)' : ''}">
       </Icon>
       <Icon id="restore" class="title-button no-drag"
-            @click.native="handleFullscreenExit"
+            @mouseup.native="handleFullscreenExit"
             v-show="middleButtonStatus === 'exit-fullscreen'"
             type="titleBarRecover"
             :state="state">


### PR DESCRIPTION
- 修复长时间mousedown后不能触发click事件，导致按键失灵