### PR TITLE
fix(landingview): wrong sequence in landing view

### DIFF
--- a/src/renderer/containers/RecentPlaylist.vue
+++ b/src/renderer/containers/RecentPlaylist.vue
@@ -461,6 +461,18 @@ export default {
     originSrc() {
       this.updateSubToTop(this.displayState);
       this.hoverIndex = this.playingIndex;
+      if (
+        this.playingIndex > this.lastIndex
+        || this.playingIndex < this.firstIndex
+      ) {
+        this.firstIndex = this.playingIndex;
+        this.shifting = true;
+        this.tranFlag = true;
+        setTimeout(() => {
+          this.shifting = false;
+          this.tranFlag = false;
+        }, 400);
+      }
       this.filename = this.pathBaseName(this.originSrc);
     },
     duration(val: number) {

--- a/src/renderer/containers/RecentPlaylist.vue
+++ b/src/renderer/containers/RecentPlaylist.vue
@@ -221,7 +221,7 @@ export default {
       updateSubToTop: subtitleActions.UPDATE_SUBTITLE_TOP,
     }),
     keyboardHandler(e: KeyboardEvent) {
-      if (this.displayState) {
+      if (this.displayState && !e.metaKey && !e.ctrlKey) {
         if (e.key === 'ArrowRight') {
           this.shifting = true;
           this.tranFlag = true;

--- a/src/renderer/containers/RecentPlaylist.vue
+++ b/src/renderer/containers/RecentPlaylist.vue
@@ -504,6 +504,25 @@ export default {
         this.firstIndex = (this.maxIndex - this.thumbnailNumber) + 1;
       }
     },
+    thumbnailNumber() {
+      if (this.playingIndex > this.lastIndex) {
+        this.lastIndex = this.playingIndex;
+        this.shifting = true;
+        this.tranFlag = true;
+        setTimeout(() => {
+          this.shifting = false;
+          this.tranFlag = false;
+        }, 400);
+      } else if (this.playingIndex < this.firstIndex) {
+        this.firstIndex = this.playingIndex;
+        this.shifting = true;
+        this.tranFlag = true;
+        setTimeout(() => {
+          this.shifting = false;
+          this.tranFlag = false;
+        }, 400);
+      }
+    },
     maxIndex(val: number, oldVal: number) {
       if (this.lastIndex === oldVal) {
         this.lastIndex = val;

--- a/src/renderer/containers/RecentPlaylistItem.vue
+++ b/src/renderer/containers/RecentPlaylistItem.vue
@@ -64,7 +64,10 @@
                 v-if="isPlaying"
                 class="icon-container"
               >
-                <transition name="fade" mode="out-in">
+                <transition
+                  name="fade"
+                  mode="out-in"
+                >
                   <Icon
                     :key="paused"
                     :style="{
@@ -75,7 +78,10 @@
                     :type="paused ? 'playlistpause' : 'playlistplay'"
                   />
                 </transition>
-                <transition name="fade" mode="out-in">
+                <transition
+                  name="fade"
+                  mode="out-in"
+                >
                   <div
                     :key="paused"
                     :style="{

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -291,13 +291,12 @@ export default {
       if (result) {
         this.$bus.$emit('database-saved');
       }
-
+      const playlistRecord = await playInfoStorageService.getPlaylistRecord(playlistId);
       const recentPlayedData = {
+        ...playlistRecord,
         items: this.isFolderList ? [videoId] : this.items,
         playedIndex: this.isFolderList ? 0 : this.playingIndex,
-        lastOpened: Date.now(),
       };
-
       await playInfoStorageService
         .updateRecentPlayedBy(playlistId, recentPlayedData as PlaylistItem);
     },
@@ -313,7 +312,7 @@ export default {
     },
     beforeUnloadHandler(e: Event) {
       if (!this.asyncTasksDone && !this.needToRestore) {
-        let savePromise = this.saveScreenshot(this.playlistId, this.videoId);
+        let savePromise = this.saveScreenshot(this.playListId, this.videoId);
         if (process.mas && this.$store.getters.source === 'drop') {
           savePromise = savePromise.then(async () => {
             await playInfoStorageService.deleteRecentPlayedBy(this.playListId);

--- a/src/renderer/interfaces/IPlayInfoStorable.ts
+++ b/src/renderer/interfaces/IPlayInfoStorable.ts
@@ -12,21 +12,27 @@ export interface IPlayInfoStorable {
   /**
    * @description 更新最近播放列表
    * @author tanghaixiang
-   * @param {number} playListID 播放列表ID
+   * @param {number} playlistId 播放列表ID
    * @param {PlaylistItem} items 播放列表元素
    * @returns {Promise<boolean>} 返回是否成功更新
    */
-  updateRecentPlayedBy(playListID: number, items: PlaylistItem): Promise<boolean>
+  updateRecentPlayedBy(playlistId: number, items: PlaylistItem): Promise<boolean>
   /**
    * @description 删除播放列表
    * @author tanghaixiang
-   * @param {number} playListID 播放列表ID
+   * @param {number} playlistId 播放列表ID
    * @returns {Promise<boolean>} 返回是否成果删除
    */
-  deleteRecentPlayedBy(playListID: number): Promise<boolean>
+  deleteRecentPlayedBy(playlistId: number): Promise<boolean>
   /**
    * @returns {Promise<PlaylistItem>}
    * 返回所有播放记录，按上次打开时间排序
    */
   getAllRecentPlayed(): Promise<PlaylistItem[]>
+  /**
+   * @param  {number} playlistId 播放列表ID
+   * @returns {Promise<PlaylistItem>}
+   * 返回指定ID的播放列表记录
+   */
+  getPlaylistRecord(playlistId: number): Promise<PlaylistItem> 
 }

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1345,7 +1345,7 @@ new Vue({
     },
     // eslint-disable-next-line complexity
     wheelEventHandler({ x }: { x: number }) {
-      if (this.duration && this.wheelDirection === 'horizontal') {
+      if (this.duration && this.wheelDirection === 'horizontal' && !this.playlistDisplayState) {
         const eventName = x < 0 ? 'seek-forward' : 'seek-backward';
         const absX = Math.abs(x);
 

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -243,10 +243,8 @@ new Vue({
     updateFullScreen() {
       if (this.isFullScreen) {
         return {
-          id: 'KeyboardEsc',
           label: this.$t('msg.window.exitFullScreen'),
-          accelerator: 'Esc',
-          enabled: !this.playlistDisplayState,
+          accelerator: 'F',
           click: () => {
             this.$bus.$emit('off-fullscreen');
             this.$electron.ipcRenderer.send('callMainWindowMethod', 'setFullScreen', [false]);
@@ -353,9 +351,6 @@ new Vue({
   watch: {
     playlistDisplayState(val: boolean) {
       if (this.menu) {
-        if (this.menu.getMenuItemById('KeyboardEsc')) {
-          this.menu.getMenuItemById('KeyboardEsc').enabled = !val;
-        }
         this.menu.getMenuItemById('KeyboardLeft').enabled = !val;
         this.menu.getMenuItemById('KeyboardRight').enabled = !val;
       }

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1413,6 +1413,13 @@ new Vue({
     });
     window.addEventListener('keydown', (e) => {
       switch (e.keyCode) {
+        case 27:
+          if (this.isFullScreen && !this.playlistDisplayState) {
+            e.preventDefault();
+            this.$bus.$emit('off-fullscreen');
+            this.$electron.ipcRenderer.send('callMainWindowMethod', 'setFullScreen', [false]);
+          }
+          break;
         case 219:
           e.preventDefault();
           this.$store.dispatch(videoActions.DECREASE_RATE);

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1462,7 +1462,7 @@ new Vue({
                 this.canSendVolumeGa = true;
               }, 1000);
             }
-            if (this.wheelDirection === 'vertical') {
+            if (this.wheelDirection === 'vertical' || this.playlistDisplayState) {
               let step = Math.abs(e.deltaY) * 0.06;
               // in windows if wheel setting more lines per step, make it limited.
               if (process.platform !== 'darwin' && step > 6) {

--- a/src/renderer/services/media/PlaylistService.ts
+++ b/src/renderer/services/media/PlaylistService.ts
@@ -30,8 +30,6 @@ export default class PlaylistService extends EventEmitter implements IPlaylistRe
     super();
     ipcRenderer.send('mediaInfo', path);
     ipcRenderer.once(`mediaInfo-${path}-reply`, async (event: any, info: string) => {
-      const { width, height } = JSON.parse(info).streams.find((stream: any) => stream.codec_type === 'video');
-
       const { duration } = JSON.parse(info).format;
       this.duration = parseFloat(duration);
       const mediaHash = await mediaQuickHash(path);
@@ -39,7 +37,7 @@ export default class PlaylistService extends EventEmitter implements IPlaylistRe
       
       if (!imgPath) {
         const imgPath = await this.mediaStorageService.generatePathBy(mediaHash, 'cover');
-        ipcRenderer.send('snapShot', { path, imgPath, duration, width, height });
+        ipcRenderer.send('snapShot', { path, imgPath, duration });
         ipcRenderer.once(`snapShot-${path}-reply`, (event: any, imgPath: string) => {
           this.imageSrc = filePathToUrl(`${imgPath}`);
           this.emit('image-loaded');

--- a/src/renderer/services/storage/PlayInfoStorageService.ts
+++ b/src/renderer/services/storage/PlayInfoStorageService.ts
@@ -70,6 +70,9 @@ export default class PlayInfoStorageService implements IPlayInfoStorable {
     const results = await info.getAll('recent-played');
     return results.sort((a: PlaylistItem, b: PlaylistItem) => b.lastOpened - a.lastOpened);
   }
+  async getPlaylistRecord(playlistId: number): Promise<PlaylistItem> {
+    return info.getValueByKey(RECENT_OBJECT_STORE_NAME, playlistId);
+  }
 }
 
 

--- a/test/unit/specs/services/storage/PlayInfoStorageService.spec.js
+++ b/test/unit/specs/services/storage/PlayInfoStorageService.spec.js
@@ -130,4 +130,12 @@ describe('PlayInfoStorageService logic service', () => {
       expect(results).to.deep.equal(expectResults);
     });
   });
+  it('should successfully getPlaylistRecord', async () => {
+    const demo = {
+      id: 1,
+    };
+    sinon.stub(info, 'getValueByKey').resolves(demo);
+    const result = await playInfoStorageService.getPlaylistRecord(1);
+    expect(result).to.be.deep.equal(demo);
+  });
 });


### PR DESCRIPTION
- lastOpened时间不合适的更新了，导致landingView显示顺序错误
- 由folderlist切换为playlist后退出到landingview后缩略图灰了，因为playListId拼成playlistId了。。。
- cmd + <-/-> 会同时触发播放列表的翻页，通过在keyboardHandler加上对metakey和ctrlkey的判断解决
- width 和 height 偶尔无法从video stream中读出，由于给snapshotVideo接口设置了默认值，因此在调用端就删了