### PR TITLE
fix(util): fix mediaHash bug with file smaller than 8192 byte

### DIFF
--- a/src/renderer/libs/utils.ts
+++ b/src/renderer/libs/utils.ts
@@ -114,7 +114,7 @@ export async function mediaQuickHash(filePath: string) {
     4096,
     Math.floor(len / 3),
     Math.floor(len / 3) * 2,
-    len - 8192,
+    len >= 8192 ? len - 8192 : 0,
   ];
   const res = await Promise.all(times(4).map(async (i) => {
     const buf = Buffer.alloc(4096);


### PR DESCRIPTION
- Fix that subtitle under 8kb cannot be properly loaded.