### PR TITLE
fix(subtitle): subtitle control problems

### DIFF
--- a/src/renderer/components/PlayingView/SubtitleList.vue
+++ b/src/renderer/components/PlayingView/SubtitleList.vue
@@ -83,7 +83,6 @@
             </div>
           </div>
         </div>
-
         <div
           v-if="0 <= computedAvailableItems.length"
           :style="{
@@ -317,7 +316,7 @@ export default {
   border: 0.5px solid rgba(255, 255, 255, 0.2);
   background: rgba(255, 255, 255, 0.15);
 }
-.refresh-animation {
+.refresh-animation .text {
   animation: menu-refresh 300ms linear 1 normal forwards;
 }
 @keyframes menu-refresh {

--- a/src/renderer/containers/TheProgressBar.vue
+++ b/src/renderer/containers/TheProgressBar.vue
@@ -4,7 +4,7 @@
     @mousemove="handleMousemove"
     @mouseenter="hoveredmouseenter"
     @mouseleave="handleMouseleave"
-    @mousedown.stop="handleMousedown"
+    @mousedown="handleMousedown"
     class="the-progress-bar no-drag"
   >
     <the-preview-thumbnail


### PR DESCRIPTION
- [x] Fix the flickering of `SubtitleControl`’s focused item after refreshing.
- [x] Fix mousedown on `TheProgressBar` also trigger controls’ animations.