### PR TITLE
Bug fix

### DIFF
--- a/src/renderer/containers/RecentPlaylist.vue
+++ b/src/renderer/containers/RecentPlaylist.vue
@@ -174,7 +174,7 @@ export default {
       movementX: 0, // movementX of move item
       movementY: 0, // movementY of move item
       shifting: false,
-      hoveredDuration: NaN,
+      hoveredDuration: this.duration,
       hoveredLastPlayedTime: NaN,
       mousePosition: {},
       backgroundDisplayState: this.displayState, // it's weird but DON'T DELETE IT!!

--- a/src/renderer/containers/RecentPlaylist.vue
+++ b/src/renderer/containers/RecentPlaylist.vue
@@ -495,7 +495,7 @@ export default {
       this.filename = this.pathBaseName(this.originSrc);
     },
     duration(val: number) {
-      if (val) this.hoveredDuration = val;
+      this.hoveredDuration = val;
     },
     playingList(val: string[]) {
       this.indexOfMovingItem = val.length;

--- a/src/renderer/containers/TheVideoController.vue
+++ b/src/renderer/containers/TheVideoController.vue
@@ -196,7 +196,6 @@ export default {
       dragOver: false,
       progressTriggerStopped: false,
       openPlayListTimeId: NaN,
-      playListState: false,
       progressDisappearDelay: 1000,
       changeState: false, // 记录是不是要改变显示速率的状态
       changeSrc: false, // 记录是否换过视频
@@ -335,9 +334,6 @@ export default {
         }, this.mousestopDelay);
       }
     },
-    playListState(val: boolean) {
-      if (val) this.updateMinimumSize();
-    },
     ratio() {
       this.updateMinimumSize();
     },
@@ -388,17 +384,17 @@ export default {
       };
     });
     if (this.isFolderList === false) {
-      this.playListState = true;
+      this.widgetsStatus.PlaylistControl.showAttached = true;
       clearTimeout(this.openPlayListTimeId);
       this.openPlayListTimeId = setTimeout(() => {
-        this.playListState = false;
+        this.widgetsStatus.PlaylistControl.showAttached = false;
       }, 4000);
     }
     this.$bus.$on('open-playlist', () => {
-      this.playListState = true;
+      this.widgetsStatus.PlaylistControl.showAttached = true;
       clearTimeout(this.openPlayListTimeId);
       this.openPlayListTimeId = setTimeout(() => {
-        this.playListState = false;
+        this.widgetsStatus.PlaylistControl.showAttached = true;
       }, 4000);
     });
     this.$bus.$on('drag-over', () => {
@@ -478,7 +474,7 @@ export default {
       this.$electron.remote.getCurrentWindow().setTouchBar(this.touchBar);
     },
     updateMinimumSize() {
-      const minimumSize = this.tempRecentPlaylistDisplayState || this.playListState
+      const minimumSize = this.tempRecentPlaylistDisplayState
         ? [512, Math.round(512 / this.ratio)]
         : [320, 180];
       this.$electron.ipcRenderer.send('callMainWindowMethod', 'setMinimumSize', minimumSize);
@@ -495,7 +491,7 @@ export default {
     },
     updatePlaylistShowAttached(event: boolean) {
       clearTimeout(this.openPlayListTimeId);
-      this.widgetsStatus.PlaylistControl.showAttached = this.playListState = event;
+      this.widgetsStatus.PlaylistControl.showAttached = event;
     },
     updatePlayButtonState(mousedownState: boolean) {
       this.mousedownOnPlayButton = mousedownState;
@@ -537,7 +533,7 @@ export default {
       // There should be a better way to handle timeline.
         try {
           this.$refs.nextVideoUI.checkNextVideoUI(videodata.time);
-          if (this.tempRecentPlaylistDisplayState || this.playListState) {
+          if (this.tempRecentPlaylistDisplayState) {
             this.$refs.recentPlaylist.updatelastPlayedTime(videodata.time);
           } else {
             this.$refs.theTimeCodes.updateTimeContent(videodata.time);
@@ -562,10 +558,7 @@ export default {
       Object.keys(this.displayState).forEach((index) => {
         tempObject[index] = !this.widgetsStatus.PlaylistControl.showAttached;
       });
-      tempObject.RecentPlaylist = (
-        this.playListState
-        || this.widgetsStatus.PlaylistControl.showAttached
-      )
+      tempObject.RecentPlaylist = this.widgetsStatus.PlaylistControl.showAttached
         && !this.dragOver;
       this.displayState = tempObject;
       this.tempRecentPlaylistDisplayState = this.widgetsStatus.PlaylistControl.showAttached;

--- a/src/renderer/containers/TheVideoController.vue
+++ b/src/renderer/containers/TheVideoController.vue
@@ -335,6 +335,9 @@ export default {
         }, this.mousestopDelay);
       }
     },
+    playListState(val: boolean) {
+      if (val) this.updateMinimumSize();
+    },
     ratio() {
       this.updateMinimumSize();
     },
@@ -475,7 +478,7 @@ export default {
       this.$electron.remote.getCurrentWindow().setTouchBar(this.touchBar);
     },
     updateMinimumSize() {
-      const minimumSize = this.tempRecentPlaylistDisplayState
+      const minimumSize = this.tempRecentPlaylistDisplayState || this.playListState
         ? [512, Math.round(512 / this.ratio)]
         : [320, 180];
       this.$electron.ipcRenderer.send('callMainWindowMethod', 'setMinimumSize', minimumSize);

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -140,6 +140,7 @@ export default {
         .then(this.$store.dispatch('saveWinSize', this.isFullScreen ? { size: this.winSizeBeforeFullScreen, angle: this.winAngleBeforeFullScreen } : { size: this.winSize, angle: this.winAngle }))
         .then(this.removeAllAudioTrack)
         .finally(() => {
+          this.$store.dispatch('Init');
           this.$bus.$off();
           this.$router.push({
             name: 'landing-view',

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -275,7 +275,8 @@ export default {
         maxVideoSize = this.winSize;
         videoSize = [this.videoHeight, this.videoWidth];
       } else {
-        maxVideoSize = this.lastWinSize[0] > 512 ? this.lastWinSize : [512, Math.round(512 / this.ratio)];
+        maxVideoSize = this.lastWinSize[0] > 512
+          ? this.lastWinSize : [512, Math.round(512 / this.ratio)];
         videoSize = [this.videoWidth, this.videoHeight];
         this.videoExisted = true;
       }

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -125,7 +125,7 @@ export default {
     this.updatePlayinglistRate({ oldDir: '', newDir: path.dirname(this.originSrc), playingList: this.playingList });
   },
   mounted() {
-    this.$event.on('back-to-landingview', () => {
+    this.$bus.$on('back-to-landingview', () => {
       let savePromise = this.saveScreenshot(this.videoId)
         .then(() => this.updatePlaylist(this.playListId));
       if (process.mas && this.$store.getters.source === 'drop') {

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -310,11 +310,11 @@ export default {
       windowRectService.uploadWindowBy(false, 'playing-view', this.winAngle, this.winAngleBeforeFullScreen, this.winSizeBeforeFullScreen, this.winPos);
     },
     async updatePlaylist(playlistId: number) {
-      if (!Number.isNaN(playlistId)) {
+      if (!Number.isNaN(playlistId) && !this.isFolderList) {
         const playlistRecord = await playInfoStorageService.getPlaylistRecord(playlistId);
         const recentPlayedData = {
           ...playlistRecord,
-          playedIndex: this.isFolderList ? 0 : this.playingIndex,
+          playedIndex: this.playingIndex,
         };
         await playInfoStorageService
           .updateRecentPlayedBy(playlistId, recentPlayedData as PlaylistItem);

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -276,7 +276,7 @@ export default {
         maxVideoSize = this.winSize;
         videoSize = [this.videoHeight, this.videoWidth];
       } else {
-        maxVideoSize = this.lastWinSize[0] > 512
+        maxVideoSize = this.lastWinSize[0] > 512 || !this.lastWinSize[0]
           ? this.lastWinSize : [512, Math.round(512 / this.ratio)];
         videoSize = [this.videoWidth, this.videoHeight];
         this.videoExisted = true;

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -275,7 +275,7 @@ export default {
         maxVideoSize = this.winSize;
         videoSize = [this.videoHeight, this.videoWidth];
       } else {
-        maxVideoSize = this.lastWinSize;
+        maxVideoSize = this.lastWinSize[0] > 512 ? this.lastWinSize : [512, Math.round(512 / this.ratio)];
         videoSize = [this.videoWidth, this.videoHeight];
         this.videoExisted = true;
       }

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -28,7 +28,7 @@ import messages from '@/locales';
 import { windowRectService } from '@/services/window/WindowRectService';
 import helpers from '@/helpers';
 import { hookVue } from '@/kerning';
-import { Video as videoActions, Subtitle as subtitleActions, SubtitleManager as smActions, SubtitleManager } from '@/store/actionTypes';
+import { Video as videoActions, Subtitle as subtitleActions, SubtitleManager as smActions, SubtitleManager, Input as InputActions } from '@/store/actionTypes';
 import { log } from '@/libs/Log';
 import asyncStorage from '@/helpers/asyncStorage';
 import { videodata } from '@/store/video';
@@ -206,6 +206,7 @@ new Vue({
           click: () => {
             this.$ga.event('app', 'volume', 'keyboard');
             this.$store.dispatch(videoActions.INCREASE_VOLUME);
+            this.$store.dispatch(InputActions.KEYDOWN_UPDATE, ({ pressedKeyboardCode: 'Equal' }));
           },
         },
         {
@@ -215,6 +216,7 @@ new Vue({
           click: () => {
             this.$ga.event('app', 'volume', 'keyboard');
             this.$store.dispatch(videoActions.DECREASE_VOLUME);
+            this.$store.dispatch(InputActions.KEYDOWN_UPDATE, ({ pressedKeyboardCode: 'Minus' }));
           },
         },
       ];

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -961,7 +961,7 @@ new Vue({
               id: 'backToLandingView',
               accelerator: 'CmdOrCtrl+Esc',
               click: () => {
-                this.$event.emit('back-to-landingview');
+                this.$bus.$emit('back-to-landingview');
               },
             },
           ],

--- a/src/renderer/services/media/RecentPlayService.ts
+++ b/src/renderer/services/media/RecentPlayService.ts
@@ -14,6 +14,7 @@ export default class RecentPlayService implements IRecentPlay {
       recentPlayedResults.map(async (value) => {
         const { items, playedIndex, id } = value;
         const coverVideoId = items[playedIndex] as number;
+        if (!coverVideoId) return null;
         const mediaItem = await info.getValueByKey('media-item', coverVideoId);
         if (!mediaItem) return null; // TODO: figure out why it wasn't saved to media-item
 

--- a/src/renderer/store/modules/Input.js
+++ b/src/renderer/store/modules/Input.js
@@ -15,7 +15,7 @@ const state = {
 
 const getters = {
   progressKeydown: state => state.pressedKeyboardCodes.includes('ArrowLeft') || state.pressedKeyboardCodes.includes('ArrowRight') || state.pressedKeyboardCodes.includes('BracketLeft') || state.pressedKeyboardCodes.includes('BracketRight'),
-  volumeKeydown: state => state.pressedKeyboardCodes.includes('KeyM'),
+  volumeKeydown: state => state.pressedKeyboardCodes.includes('KeyM') || state.pressedKeyboardCodes.includes('Minus') || state.pressedKeyboardCodes.includes('Equal'),
   leftMousedown: state => state.pressedMouseButtonNames.includes('left'),
   wheelTriggered: state => state.wheelTimestamp,
   volumeWheelTriggered: ({ wheelDirection, wheelComponentName }) => (

--- a/src/renderer/store/modules/Playlist.js
+++ b/src/renderer/store/modules/Playlist.js
@@ -62,6 +62,12 @@ const getters = {
 };
 
 const mutations = {
+  Init(state) {
+    state.id = NaN;
+    state.items = [];
+    state.playList = [];
+    state.isFolderList = undefined;
+  },
   source(state, type) {
     state.source = type;
   },
@@ -100,6 +106,9 @@ const mutations = {
 };
 
 const actions = {
+  Init({ commit }) {
+    commit('Init');
+  },
   PlayingList({ commit }, payload) {
     commit('isPlayingList');
     if (payload.paths) commit('playList', payload.paths);


### PR DESCRIPTION
- 从landingview点开叠叠图后弹出播放列表时，缩小窗口可以缩到512px以下，加了个判断
- 窗口记忆功能会导致打开时小于应有的最小尺寸
- 注册了多个event而没有删除导致存了错误的图，改用eventBus来传事件
- 加了判断防止一条记录产生错误导致landingview所有的都加载不出来
- 试图解决playlist打开后duration为NaN的问题。。