### PR TITLE
fix(subtitle): use mediaHash to store subtitle preferences

### DIFF
--- a/src/main/helpers/mediaTasksPlugin.ts
+++ b/src/main/helpers/mediaTasksPlugin.ts
@@ -1,59 +1,65 @@
-import { app, ipcMain, splayerx } from 'electron';
+import {
+  app, ipcMain, splayerx, Event,
+} from 'electron';
 import { existsSync } from 'fs';
+
+function reply(event: Event, channel: string, ...args: any[]) {
+  if (event.sender && !event.sender.isDestroyed()) event.reply(channel, ...args);
+}
 
 app.on('ready', () => {
   ipcMain.on('media-info-request', (event, path) => {
     if (existsSync(path)) {
-      splayerx.getMediaInfo(path, info => event.reply('media-info-reply', undefined, info));
-    } else event.reply('media-info-reply', new Error('File does not exist.'));
+      splayerx.getMediaInfo(path, info => reply(event, 'media-info-reply', undefined, info));
+    } else reply(event, 'media-info-reply', new Error('File does not exist.'));
   });
   ipcMain.on('snapshot-request', (event,
     videoPath, imagePath,
     timeString,
     width, height) => {
-    if (existsSync(imagePath)) event.reply('snapshot-reply', undefined, imagePath);
+    if (existsSync(imagePath)) reply(event, 'snapshot-reply', undefined, imagePath);
     else if (existsSync(videoPath)) {
       splayerx.snapshotVideo(
         videoPath, imagePath,
         timeString,
         width.toString(), height.toString(),
         (err) => {
-          if (err === '0' && existsSync(imagePath)) event.reply('snapshot-reply', undefined, imagePath);
-          else event.reply('snapshot-reply', new Error(err));
+          if (err === '0' && existsSync(imagePath)) reply(event, 'snapshot-reply', undefined, imagePath);
+          else reply(event, 'snapshot-reply', new Error(err));
         },
       );
-    } else event.reply('snapshot-reply', new Error('File does not exist.'));
+    } else reply(event, 'snapshot-reply', new Error('File does not exist.'));
   });
   ipcMain.on('subtitle-request', (event,
     videoPath, subtitlePath,
     streamIndex) => {
-    if (existsSync(subtitlePath)) event.reply('subtitle-reply', undefined, subtitlePath);
+    if (existsSync(subtitlePath)) reply(event, 'subtitle-reply', undefined, subtitlePath);
     else if (existsSync(videoPath)) {
       splayerx.extractSubtitles(
         videoPath, subtitlePath,
         streamIndex,
         (err) => {
-          if (err === '0' && existsSync(subtitlePath)) event.reply('subtitle-reply', undefined, subtitlePath);
-          else event.reply('subtitle-reply', new Error(err));
+          if (err === '0' && existsSync(subtitlePath)) reply(event, 'subtitle-reply', undefined, subtitlePath);
+          else reply(event, 'subtitle-reply', new Error(err));
         },
       );
-    } else event.reply('subtitle-reply', new Error('File does not exist.'));
+    } else reply(event, 'subtitle-reply', new Error('File does not exist.'));
   });
   ipcMain.on('thumbnail-request', (event,
     videoPath, imagePath,
     thumbnailWidth,
     rowThumbnailCount, columnThumbnailCount) => {
-    if (existsSync(imagePath)) event.reply('thumbnail-reply', undefined, imagePath);
+    if (existsSync(imagePath)) reply(event, 'thumbnail-reply', undefined, imagePath);
     else if (existsSync(videoPath)) {
       splayerx.generateThumbnails(
         videoPath, imagePath,
         thumbnailWidth.toString(),
         rowThumbnailCount.toString(), columnThumbnailCount.toString(),
         (err) => {
-          if (err === '0' && existsSync(imagePath)) event.reply('thumbnail-reply', undefined, imagePath);
-          else event.reply('thumbnail-reply', new Error(err));
+          if (err === '0' && existsSync(imagePath)) reply(event, 'thumbnail-reply', undefined, imagePath);
+          else reply(event, 'thumbnail-reply', new Error(err));
         },
       );
-    } else event.reply('thumbnail-reply', new Error('File does not exist.'));
+    } else reply(event, 'thumbnail-reply', new Error('File does not exist.'));
   });
 });

--- a/src/renderer/containers/LandingView.vue
+++ b/src/renderer/containers/LandingView.vue
@@ -128,7 +128,6 @@ import PlaylistItem from '@/components/LandingView/PlaylistItem.vue';
 import VideoItem from '@/components/LandingView/VideoItem.vue';
 import { log } from '@/libs/Log';
 import Sagi from '@/libs/sagi';
-import { deleteSubtitlesByPlaylistId } from '../services/storage/subtitle';
 
 Vue.component('PlaylistItem', PlaylistItem);
 Vue.component('VideoItem', VideoItem);
@@ -362,7 +361,6 @@ export default {
         this.lastIndex = this.landingViewItems.length;
       }
       playInfoStorageService.deleteRecentPlayedBy(deletedItem.id);
-      deleteSubtitlesByPlaylistId(deletedItem.id);
     },
   },
 };

--- a/src/renderer/containers/VideoCanvas.vue
+++ b/src/renderer/containers/VideoCanvas.vue
@@ -51,7 +51,6 @@ import { Video as videoActions } from '@/store/actionTypes';
 import { videodata } from '@/store/video';
 import BaseVideoPlayer from '@/components/PlayingView/BaseVideoPlayer.vue';
 import { MediaItem, PlaylistItem } from '../interfaces/IDB';
-import { deleteSubtitlesByPlaylistId } from '../services/storage/subtitle';
 
 export default {
   name: 'VideoCanvas',
@@ -130,7 +129,6 @@ export default {
       if (process.mas && this.$store.getters.source === 'drop') {
         savePromise = savePromise.then(async () => {
           await playInfoStorageService.deleteRecentPlayedBy(this.playListId);
-          await deleteSubtitlesByPlaylistId(this.playListId);
         });
       }
       savePromise
@@ -354,7 +352,6 @@ export default {
         if (process.mas && this.$store.getters.source === 'drop') {
           savePromise = savePromise.then(async () => {
             await playInfoStorageService.deleteRecentPlayedBy(this.playListId);
-            await deleteSubtitlesByPlaylistId(this.playListId);
           });
         }
         savePromise

--- a/src/renderer/interfaces/ISubtitleStorage.ts
+++ b/src/renderer/interfaces/ISubtitleStorage.ts
@@ -25,8 +25,7 @@ interface IPrimarySecondary<T> {
 }
 export type SelectedSubtitle = { hash: string, source?: IOrigin };
 export interface ISubtitlePreference {
-  playlistId: number;
-  mediaId: string;
+  mediaHash: string;
   list: IStoredSubtitleItem[];
   language: IPrimarySecondary<LanguageCode>;
   selected: IPrimarySecondary<SelectedSubtitle>;

--- a/src/renderer/services/storage/subtitle/db.ts
+++ b/src/renderer/services/storage/subtitle/db.ts
@@ -1,6 +1,6 @@
 import { DBSchema, IDBPDatabase, openDB } from 'idb';
 import {
-  unionWith, uniqWith, remove, isEqual, some, keyBy, mergeWith, isFinite,
+  unionWith, uniqWith, remove, isEqual, some, pick, keyBy, mergeWith, isFinite,
 } from 'lodash';
 import { LanguageCode } from '@/libs/language';
 import { DATADB_NAME } from '@/constants';
@@ -11,7 +11,7 @@ import {
   IStoredSubtitle, IStoredSubtitleItem, ISubtitlePreference, SelectedSubtitle,
 } from '@/interfaces/ISubtitleStorage';
 
-interface IDataDBV2 extends DBSchema {
+interface IDataDBV3 extends DBSchema {
   'subtitles': {
     key: string;
     value: IStoredSubtitle;
@@ -23,6 +23,16 @@ interface IDataDBV2 extends DBSchema {
       'byPlaylist': number,
       'byMediaItem': string,
     },
+  };
+}
+interface IDataDBV4 extends DBSchema {
+  'subtitles': {
+    key: string;
+    value: IStoredSubtitle;
+  };
+  'subtitle-preferences': {
+    key: string;
+    value: ISubtitlePreference;
   };
 }
 
@@ -51,22 +61,26 @@ interface IUpdateSubtitleItemOptions {
 }
 
 export class SubtitleDataBase {
-  private db: IDBPDatabase<IDataDBV2>;
+  private db: IDBPDatabase<IDataDBV4>;
 
   private async getDb() {
     if (!this.db) {
-      this.db = await openDB<IDataDBV2>(
+      this.db = await openDB<IDataDBV4>(
         DATADB_NAME,
-        3,
+        4,
         {
           async upgrade(db, version) {
+            if (version === 0) {
+              db.createObjectStore('subtitles', { keyPath: 'hash' });
+            }
             if (version > 0 && version < 3) {
               db.deleteObjectStore('subtitles');
+              db.createObjectStore('subtitles', { keyPath: 'hash' });
+            } else if (version === 3) {
+              const v3Db = db as unknown as IDBPDatabase<IDataDBV3>;
+              v3Db.deleteObjectStore('preferences');
             }
-            db.createObjectStore('subtitles', { keyPath: 'hash' });
-            const preferenceStore = db.createObjectStore('preferences', { autoIncrement: true });
-            preferenceStore.createIndex('byPlaylist', 'playlistId');
-            preferenceStore.createIndex('byMediaItem', 'mediaId');
+            db.createObjectStore('subtitle-preferences', { keyPath: 'mediaHash' });
           },
         },
       );
@@ -163,27 +177,13 @@ export class SubtitleDataBase {
     return undefined;
   }
 
-  public async retrieveSubtitlePreference(playlistId: number, mediaItemId: string) {
-    let cursor = await ((await this.getDb())
-      .transaction('preferences', 'readonly')
-      .objectStore('preferences')
-      .openCursor());
-    while (cursor) {
-      if (cursor.value.playlistId === playlistId && cursor.value.mediaId === mediaItemId) {
-        return cursor.value;
-      }
-      cursor = await cursor.continue();
-    }
-    return undefined;
+  public async retrieveSubtitlePreference(mediaHash: string) {
+    return (await this.getDb()).get('subtitle-preferences', mediaHash);
   }
 
-  private static generateDefaultPreference(
-    playlistId: number,
-    mediaItemId: string,
-  ): ISubtitlePreference {
+  private static generateDefaultPreference(mediaHash: string): ISubtitlePreference {
     return {
-      playlistId,
-      mediaId: mediaItemId,
+      mediaHash,
       language: {
         primary: LanguageCode.Default,
         secondary: LanguageCode.Default,
@@ -196,48 +196,57 @@ export class SubtitleDataBase {
     };
   }
 
-  public async retrieveSubtitleList(playlistId: number, mediaItemId: string) {
-    const preference = await this.retrieveSubtitlePreference(playlistId, mediaItemId);
+  public async retrieveSubtitleList(mediaHash: string) {
+    const preference = await this.retrieveSubtitlePreference(mediaHash);
     return preference ? preference.list : [];
   }
 
+  private static unionSubtitleList(
+    subtitles: IStoredSubtitleItem[],
+    subtitlesToUnion: IStoredSubtitleItem[],
+  ) {
+    return unionWith(
+      subtitles, subtitlesToUnion,
+      (subtitle, newSubtitle) => isEqual(
+        pick(subtitle, ['hash', 'type', 'source']),
+        pick(newSubtitle, ['hash', 'type', 'source']),
+      ),
+    );
+  }
+
+  private static uniqSubtitleList(subtitles: IStoredSubtitleItem[]) {
+    return uniqWith(
+      subtitles,
+      (subtitle, newSubtitle) => isEqual(
+        pick(subtitle, ['hash', 'type', 'source']),
+        pick(newSubtitle, ['hash', 'type', 'source']),
+      ),
+    );
+  }
+
   public async addSubtitleItemsToList(
-    playlistId: number,
-    mediaItemId: string,
+    mediaHash: string,
     subtitles: IStoredSubtitleItem[],
   ) {
-    subtitles = uniqWith(subtitles, (
-      { hash: hash1, source: source1 },
-      { hash: hash2, source: source2 },
-    ) => hash1 === hash2 && isEqual(source1, source2));
+    subtitles = SubtitleDataBase.uniqSubtitleList(subtitles);
     const objectStore = (await this.getDb())
-      .transaction('preferences', 'readwrite')
-      .objectStore('preferences');
-    let preference;
-    let key;
-    let cursor = await objectStore.openCursor();
-    while (cursor && !preference && !key) {
-      if (cursor.value.playlistId === playlistId && cursor.value.mediaId === mediaItemId) {
-        preference = cursor.value;
-        key = cursor.key;
-      }
-      cursor = await cursor.continue();
-    }
+      .transaction('subtitle-preferences', 'readwrite')
+      .objectStore('subtitle-preferences');
+    const preference = await objectStore.get(mediaHash);
     if (!preference) {
       return objectStore.add({
-        ...SubtitleDataBase.generateDefaultPreference(playlistId, mediaItemId),
+        ...SubtitleDataBase.generateDefaultPreference(mediaHash),
         list: subtitles,
       });
     }
     return objectStore.put({
       ...preference,
-      list: unionWith(subtitles, preference.list, isEqual),
-    }, key);
+      list: SubtitleDataBase.unionSubtitleList(preference.list, subtitles),
+    });
   }
 
   public async updateSubtitleList(
-    playlistId: number,
-    mediaItemId: string,
+    mediaHash: string,
     subtitlesToUpdate: IUpdateSubtitleItemOptions[],
   ) {
     subtitlesToUpdate = uniqWith(subtitlesToUpdate, (
@@ -245,77 +254,54 @@ export class SubtitleDataBase {
       { hash: hash2, source: source2 },
     ) => hash1 === hash2 && isEqual(source1, source2));
     const objectStore = (await this.getDb())
-      .transaction('preferences', 'readwrite')
-      .objectStore('preferences');
-    let preference;
-    let list: IStoredSubtitleItem[] = [];
-    let key;
-    let cursor = await objectStore.openCursor();
-    while (cursor && !preference && !key) {
-      if (cursor.value.playlistId === playlistId && cursor.value.mediaId === mediaItemId) {
-        preference = cursor.value;
-        list = Object.values(mergeWith(
-          keyBy(preference.list, ({ hash }) => hash),
-          keyBy(subtitlesToUpdate, ({ hash }) => hash),
-          (objVal: IStoredSubtitleItem, srcVal: IStoredSubtitleItem) => {
-            const destObj = { ...objVal };
-            const {
-              type, source, videoSegments, delay,
-            } = srcVal;
-            if (type) destObj.type = type;
-            if (source) destObj.source = source;
-            if (videoSegments) destObj.videoSegments = videoSegments;
-            if (isFinite(delay)) destObj.delay = delay;
-            return destObj;
-          },
-        ));
-        key = cursor.key;
-      }
-      cursor = await cursor.continue();
-    }
+      .transaction('subtitle-preferences', 'readwrite')
+      .objectStore('subtitle-preferences');
+    const preference = await objectStore.get(mediaHash);
     if (!preference) {
-      return objectStore.add({
-        ...SubtitleDataBase.generateDefaultPreference(playlistId, mediaItemId), list,
-      });
+      return objectStore.add(SubtitleDataBase.generateDefaultPreference(mediaHash));
     }
-    return objectStore.put({ ...preference, list }, key);
+    return objectStore.put({
+      ...preference,
+      list: Object.values(mergeWith(
+        keyBy(preference.list, ({ hash }) => hash),
+        keyBy(subtitlesToUpdate, ({ hash }) => hash),
+        (objVal: IStoredSubtitleItem, srcVal: IStoredSubtitleItem) => {
+          const destObj = { ...objVal };
+          const {
+            type, source, videoSegments, delay,
+          } = srcVal;
+          if (type) destObj.type = type;
+          if (source) destObj.source = source;
+          if (videoSegments) destObj.videoSegments = videoSegments;
+          if (isFinite(delay)) destObj.delay = delay;
+          return destObj;
+        },
+      )),
+    });
   }
 
   public async removeSubtitleItemsFromList(
-    playlistId: number,
-    mediaItemId: string,
+    mediaHash: string,
     subtitles: IStoredSubtitleItem[],
   ) {
-    subtitles = uniqWith(subtitles, (
-      { hash: hash1, source: source1 },
-      { hash: hash2, source: source2 },
-    ) => hash1 === hash2 && isEqual(source1, source2));
+    subtitles = SubtitleDataBase.uniqSubtitleList(subtitles);
     const objectStore = (await this.getDb())
-      .transaction('preferences', 'readwrite')
-      .objectStore('preferences');
-    let preference;
-    let key;
-    let cursor = await objectStore.openCursor();
-    while (cursor && !preference && !key) {
-      if (cursor.value.playlistId === playlistId && cursor.value.mediaId === mediaItemId) {
-        preference = cursor.value;
-        key = cursor.key;
-      }
-      cursor = await cursor.continue();
-    }
+      .transaction('subtitle-preferences', 'readwrite')
+      .objectStore('subtitle-preferences');
+    const preference = await objectStore.get(mediaHash);
     if (!preference) {
-      return objectStore.add(SubtitleDataBase.generateDefaultPreference(playlistId, mediaItemId));
+      return objectStore.add(SubtitleDataBase.generateDefaultPreference(mediaHash));
     }
     const { list: existedList } = preference;
     remove(existedList, sub => some(subtitles, sub));
     return objectStore.put({
       ...preference,
       list: existedList,
-    }, key);
+    });
   }
 
-  public async retrieveSubtitleLanguage(playlistId: number, mediaItemId: string) {
-    const preference = await this.retrieveSubtitlePreference(playlistId, mediaItemId);
+  public async retrieveSubtitleLanguage(mediaHash: string) {
+    const preference = await this.retrieveSubtitlePreference(mediaHash);
     return preference ? preference.language : {
       primary: LanguageCode.Default,
       secondary: LanguageCode.Default,
@@ -323,27 +309,16 @@ export class SubtitleDataBase {
   }
 
   public async storeSubtitleLanguage(
-    playlistId: number,
-    mediaItemId: string,
+    mediaHash: string,
     languageCodes: LanguageCode[],
   ) {
     const objectStore = (await this.getDb())
-      .transaction('preferences', 'readwrite')
-      .objectStore('preferences');
-    let preference;
-    let key;
-    let cursor = await objectStore.openCursor();
-    while (cursor && !preference && !key) {
-      if (cursor.value.playlistId === playlistId && cursor.value.mediaId === mediaItemId) {
-        preference = cursor.value;
-        key = cursor.key;
-      }
-      cursor = await cursor.continue();
-    }
-
+      .transaction('subtitle-preferences', 'readwrite')
+      .objectStore('subtitle-preferences');
+    const preference = await objectStore.get(mediaHash);
     if (!preference) {
       return objectStore.add({
-        ...SubtitleDataBase.generateDefaultPreference(playlistId, mediaItemId),
+        ...SubtitleDataBase.generateDefaultPreference(mediaHash),
         language: {
           primary: languageCodes[0],
           secondary: languageCodes[1],
@@ -356,35 +331,25 @@ export class SubtitleDataBase {
         primary: languageCodes[0],
         secondary: languageCodes[1],
       },
-    }, key);
+    });
   }
 
-  public async retrieveSelectedSubtitles(playlistId: number, mediaItemId: string) {
-    const preference = await this.retrieveSubtitlePreference(playlistId, mediaItemId);
+  public async retrieveSelectedSubtitles(mediaHash: string) {
+    const preference = await this.retrieveSubtitlePreference(mediaHash);
     return preference ? preference.selected : [];
   }
 
   public async storeSelectedSubtitles(
-    playlistId: number,
-    mediaItemId: string,
+    mediaHash: string,
     subtitles: SelectedSubtitle[],
   ) {
     const objectStore = (await this.getDb())
-      .transaction('preferences', 'readwrite')
-      .objectStore('preferences');
-    let preference;
-    let key;
-    let cursor = await objectStore.openCursor();
-    while (cursor && !preference && !key) {
-      if (cursor.value.playlistId === playlistId && cursor.value.mediaId === mediaItemId) {
-        preference = cursor.value;
-        key = cursor.key;
-      }
-      cursor = await cursor.continue();
-    }
+      .transaction('subtitle-preferences', 'readwrite')
+      .objectStore('subtitle-preferences');
+    const preference = await objectStore.get(mediaHash);
     if (!preference) {
       return objectStore.add({
-        ...SubtitleDataBase.generateDefaultPreference(playlistId, mediaItemId),
+        ...SubtitleDataBase.generateDefaultPreference(mediaHash),
         selected: {
           primary: subtitles[0],
           secondary: subtitles[1],
@@ -397,22 +362,6 @@ export class SubtitleDataBase {
         primary: subtitles[0],
         secondary: subtitles[1],
       },
-    }, key);
-  }
-
-  public async deleteSubtitlesByPlaylistId(playlistId: number) {
-    const playlistStore = await (await this.getDb())
-      .transaction('preferences', 'readwrite')
-      .objectStore('preferences');
-    let cursor = await playlistStore.openCursor();
-    const subtitlesToRemove: IRemoveSubtitleOptions[] = [];
-    while (cursor) {
-      if (cursor.value.playlistId === playlistId) {
-        await playlistStore.delete(cursor.key);
-        subtitlesToRemove.push(...cursor.value.list);
-      }
-      cursor = await cursor.continue();
-    }
-    return this.removeSubtitles(subtitlesToRemove);
+    });
   }
 }

--- a/src/renderer/services/storage/subtitle/index.ts
+++ b/src/renderer/services/storage/subtitle/index.ts
@@ -10,7 +10,7 @@ import { loadLocalFile } from '@/services/subtitle/utils';
 import { embeddedSrcLoader, IEmbeddedOrigin } from '@/services/subtitle/loaders/embedded';
 import {
   cacheEmbeddedSubtitle, cacheLocalSubtitle, cacheOnlineSubtitle,
-  isCachedSubtitle, removeCachedSubtitles,
+  isCachedSubtitle,
   addNewSourceToDb,
 } from './file';
 
@@ -36,28 +36,26 @@ export async function updateSubtitle(subtitle: Entity) {
     hash, source, format, language,
   });
 }
-export function retrieveSubtitlePreference(playlistId: number, mediaItemId: string) {
-  return db.retrieveSubtitlePreference(playlistId, mediaItemId);
+export function retrieveSubtitlePreference(mediaHash: string) {
+  return db.retrieveSubtitlePreference(mediaHash);
 }
-export function retrieveStoredSubtitleList(playlistId: number, mediaItemId: string) {
-  return db.retrieveSubtitleList(playlistId, mediaItemId);
+export function retrieveStoredSubtitleList(mediaHash: string) {
+  return db.retrieveSubtitleList(mediaHash);
 }
 export function addSubtitleItemsToList(
   subtitles: SubtitleControlListItem[],
-  playlistId: number,
-  mediaItemId: string,
+  mediaHash: string,
 ) {
   const storedSubtitles = subtitles.filter(s => s).map(({
     hash, type, source, delay,
   }) => ({
     hash, type, source, delay,
   }));
-  return db.addSubtitleItemsToList(playlistId, mediaItemId, storedSubtitles);
+  return db.addSubtitleItemsToList(mediaHash, storedSubtitles);
 }
 export function updateSubtitleList(
   subtitles: SubtitleControlListItem[],
-  playlistId: number,
-  mediaItemId: string,
+  mediaHash: string,
 ) {
   const subtitlesToUpdate = subtitles
     .filter(sub => !!sub)
@@ -66,42 +64,33 @@ export function updateSubtitleList(
     }) => ({
       hash, type, source, delay,
     }));
-  return db.updateSubtitleList(playlistId, mediaItemId, subtitlesToUpdate);
+  return db.updateSubtitleList(mediaHash, subtitlesToUpdate);
 }
 export function removeSubtitleItemsFromList(
   subtitles: SubtitleControlListItem[],
-  playlistId: number,
-  mediaItemId: string,
+  mediaHash: string,
 ) {
   const storedSubtitles = subtitles.filter(s => s).map(({
     hash, type, source, delay,
   }) => ({
     hash, type, source, delay,
   }));
-  return db.removeSubtitleItemsFromList(playlistId, mediaItemId, storedSubtitles);
+  return db.removeSubtitleItemsFromList(mediaHash, storedSubtitles);
 }
 export function storeSubtitleLanguage(
   languageCodes: LanguageCode[],
-  playlistId: number,
-  mediaItemId: string,
+  mediaHash: string,
 ) {
-  return db.storeSubtitleLanguage(playlistId, mediaItemId, languageCodes);
+  return db.storeSubtitleLanguage(mediaHash, languageCodes);
 }
 export function storeSelectedSubtitles(
   subs: SelectedSubtitle[],
-  playlistId: number,
-  mediaItemId: string,
+  mediaHash: string,
 ) {
-  return db.storeSelectedSubtitles(playlistId, mediaItemId, subs);
+  return db.storeSelectedSubtitles(mediaHash, subs);
 }
-export function retrieveSelectedSubtitles(playlistId: number, mediaItemId: string) {
-  return db.retrieveSelectedSubtitles(playlistId, mediaItemId);
-}
-export async function deleteSubtitlesByPlaylistId(playlistId: number) {
-  const hashes = await db.deleteSubtitlesByPlaylistId(playlistId);
-  const cachedSubtitleSources = await removeCachedSubtitles(hashes);
-  await db.removeSubtitles(cachedSubtitleSources
-    .map(({ hash, source }) => ({ hash, source: source.source })));
+export function retrieveSelectedSubtitles(mediaHash: string) {
+  return db.retrieveSelectedSubtitles(mediaHash);
 }
 
 export class DatabaseGenerator implements IEntityGenerator {

--- a/src/renderer/store/modules/Subtitle.ts
+++ b/src/renderer/store/modules/Subtitle.ts
@@ -195,7 +195,7 @@ const actions = {
   async [a.delete]({ state, rootGetters }: any) {
     const subtitleToRemoveFromList = rootGetters.list
       .find((sub: SubtitleControlListItem) => sub.id === state.moduleId);
-    const { playlistId, mediaItemId } = store.state.SubtitleManager;
+    const { mediaHash } = store.state.SubtitleManager;
     const subtitle = subtitleMap.get(state.moduleId);
     if (subtitle) {
       subtitleMap.delete(state.moduleId);
@@ -205,7 +205,7 @@ const actions = {
         if (cachedSource) await removeSubtitle({ ...subtitle.entity, source: cachedSource });
       }
     }
-    removeSubtitleItemsFromList([subtitleToRemoveFromList], playlistId, mediaItemId);
+    removeSubtitleItemsFromList([subtitleToRemoveFromList], mediaHash);
   },
   async [a.upload]({ state, dispatch, rootGetters }: any) {
     const subtitle = subtitleMap.get(state.moduleId);

--- a/src/renderer/store/modules/SubtitleManager.ts
+++ b/src/renderer/store/modules/SubtitleManager.ts
@@ -44,8 +44,7 @@ const sortOfTypes = {
 let unwatch: Function;
 
 type SubtitleManagerState = {
-  playlistId: number,
-  mediaItemId: string,
+  mediaHash: string,
   primarySubtitleId: string,
   secondarySubtitleId: string,
   isRefreshing: boolean,
@@ -54,8 +53,7 @@ type SubtitleManagerState = {
   secondaryDelay: number,
 }
 const state = {
-  playlistId: 0,
-  mediaItemId: '',
+  mediaHash: '',
   primarySubtitleId: '',
   secondarySubtitleId: '',
   isRefreshing: false,
@@ -91,11 +89,8 @@ const getters = {
   calculatedNoSub(state: SubtitleManagerState, { list }: any) { return !list.length; },
 };
 const mutations = {
-  [m.setPlaylistId](state: SubtitleManagerState, id: number) {
-    state.playlistId = id;
-  },
-  [m.setMediaItemId](state: SubtitleManagerState, id: string) {
-    state.mediaItemId = id;
+  [m.setMediaHash](state: SubtitleManagerState, hash: string) {
+    state.mediaHash = hash;
   },
   [m.setPrimarySubtitleId](state: SubtitleManagerState, id: string) {
     state.primarySubtitleId = id;
@@ -134,13 +129,11 @@ type AddDatabaseSubtitlesOptions = {
     primary?: SelectedSubtitle;
     secondary?: SelectedSubtitle;
   };
-  playlistId: number;
-  mediaItemId: string;
+  mediaHash: string,
 };
 type AddSubtitleOptions = {
   generator: IEntityGenerator;
-  playlistId: number;
-  mediaItemId: string;
+  mediaHash: string,
 };
 function privacyConfirm(): Promise<boolean> {
   const { $bus } = Vue.prototype;
@@ -179,11 +172,9 @@ function fetchOnlineListWithBubble(
   });
 }
 function initializeManager({ getters, commit, dispatch }: any) {
-  const { playListId, originSrc, mediaHash } = getters;
   const list = getters.list as SubtitleControlListItem[];
   list.forEach(s => dispatch(a.removeSubtitle, s.id));
-  commit(m.setPlaylistId, playListId);
-  commit(m.setMediaItemId, `${mediaHash}-${originSrc}`);
+  commit(m.setMediaHash, getters.mediaHash);
   dispatch(a.refreshSubtitlesInitially);
 }
 const debouncedInitializeManager = debounce(initializeManager, 1000);
@@ -192,8 +183,7 @@ const actions = {
     debouncedInitializeManager(context);
   },
   [a.resetManager]({ commit }: any) {
-    commit(m.setPlaylistId, 0);
-    commit(m.setMediaItemId, '');
+    commit(m.setMediaHash, '');
     commit(m.setPrimarySubtitleId, '');
     commit(m.setSecondarySubtitleId, '');
     commit(m.setIsRefreshing, false);
@@ -209,14 +199,13 @@ const actions = {
     commit(m.setIsRefreshing, true);
     dispatch(a.startAISelection);
 
-    const { playlistId, mediaItemId } = state;
     const {
       primaryLanguage, secondaryLanguage,
       originSrc,
       privacyAgreement,
     } = getters;
     const list = getters.list as SubtitleControlListItem[];
-    const preference = await retrieveSubtitlePreference(playlistId, mediaItemId);
+    const preference = await retrieveSubtitlePreference(state.mediaHash);
     const hasStoredSubtitles = !!preference && !!preference.list.length;
     const languageHasChanged = (
       !preference
@@ -231,8 +220,7 @@ const actions = {
         dispatch(a.addDatabaseSubtitles, {
           storedList: preference.list,
           selected: preference.selected,
-          playlistId,
-          mediaItemId,
+          mediaHash: state.mediaHash,
         }),
         new Promise((resolve, reject) => setTimeout(() => reject(new Error('timeout')), 10000)),
       ])
@@ -248,8 +236,7 @@ const actions = {
       await dispatch(a.addDatabaseSubtitles, {
         storedList: preference.list,
         selected: preference.selected,
-        playlistId,
-        mediaItemId,
+        mediaHash: state.mediaHash,
       });
     }
 
@@ -261,7 +248,9 @@ const actions = {
     const embeddedNeeded = !list
       .some(({ type }: SubtitleControlListItem) => type === Type.Embedded);
     if (embeddedNeeded) {
-      retrieveEmbeddedList(originSrc).then(streams => dispatch(a.addEmbeddedSubtitles, streams));
+      retrieveEmbeddedList(originSrc)
+        .then(streams => dispatch(a.addEmbeddedSubtitles, streams))
+        .then(() => addSubtitleItemsToList(getters.list, state.mediaHash));
     }
 
     return Promise.race([
@@ -274,8 +263,8 @@ const actions = {
       .catch(console.error)
       .finally(() => {
         dispatch(a.stopAISelection);
-        storeSubtitleLanguage([primaryLanguage, secondaryLanguage], playlistId, mediaItemId);
-        addSubtitleItemsToList(list, playlistId, mediaItemId);
+        storeSubtitleLanguage([primaryLanguage, secondaryLanguage], state.mediaHash);
+        addSubtitleItemsToList(getters.list, state.mediaHash);
         dispatch(a.checkLocalSubtitles);
         dispatch(a.checkSubtitleList);
         commit(m.setIsRefreshing, false);
@@ -285,13 +274,11 @@ const actions = {
   async [a.refreshSubtitles]({
     state, getters, dispatch, commit,
   }: any) {
-    const { playlistId, mediaItemId } = state;
     const {
       originSrc,
       primaryLanguage, secondaryLanguage,
       privacyAgreement,
     } = getters;
-    const list = getters.list as SubtitleControlListItem[];
 
     primarySelectionComplete = false;
     secondarySelectionComplete = false;
@@ -311,8 +298,8 @@ const actions = {
       .catch(console.error)
       .finally(() => {
         dispatch(a.stopAISelection);
-        storeSubtitleLanguage([primaryLanguage, secondaryLanguage], playlistId, mediaItemId);
-        addSubtitleItemsToList(list, playlistId, mediaItemId);
+        storeSubtitleLanguage([primaryLanguage, secondaryLanguage], state.mediaHash);
+        addSubtitleItemsToList(getters.list, state.mediaHash);
         dispatch(a.checkLocalSubtitles);
         dispatch(a.checkSubtitleList);
         commit(m.setIsRefreshing, false);
@@ -377,17 +364,16 @@ const actions = {
     return Promise.all(
       paths.map((path: string) => dispatch(a.addSubtitle, {
         generator: new LocalGenerator(path),
-        playlistId: state.playlistId,
-        mediaItemId: state.mediaItemId,
+        mediaHash: state.mediaHash,
       })),
     );
   },
   async [a.addLocalSubtitlesWithSelect]({ state, dispatch, getters }: any, paths: string[]) {
     let selectedHash = paths[0];
-    const { playlistId, mediaItemId } = state;
+    const { mediaHash } = state;
     const list = getters.list as SubtitleControlListItem[];
     // tempoary solution, need db validation schema to ensure data consistent
-    if (playlistId && mediaItemId) {
+    if (mediaHash) {
       return Promise.all(
         paths.map(async (path: string, i: number) => {
           const g = new LocalGenerator(path);
@@ -398,12 +384,11 @@ const actions = {
           }
           return dispatch(a.addSubtitle, {
             generator: g,
-            playlistId,
-            mediaItemId,
+            mediaHash,
           });
         }),
       ).then((localEntities: SubtitleControlListItem[]) => {
-        addSubtitleItemsToList(localEntities, playlistId, mediaItemId);
+        addSubtitleItemsToList(localEntities, state.mediaHash);
         const sub = list.find((sub: SubtitleControlListItem) => sub.hash === selectedHash);
         if (sub && getters.isFirstSubtitle) {
           dispatch(a.changePrimarySubtitle, sub.id);
@@ -418,8 +403,7 @@ const actions = {
     return Promise.all(
       streams.map(stream => dispatch(a.addSubtitle, {
         generator: new EmbeddedGenerator(stream[0], stream[1]),
-        playlistId: state.playlistId,
-        mediaItemId: state.mediaItemId,
+        mediaHash: state.mediaHash,
       })),
     );
   },
@@ -427,17 +411,18 @@ const actions = {
     return Promise.all(
       transcriptInfoList.map((info: TranscriptInfo) => dispatch(a.addSubtitle, {
         generator: new OnlineGenerator(info),
-        playlistId: state.playlistId,
-        mediaItemId: state.mediaItemId,
+        mediaHash: state.mediaHash,
       })),
     );
   },
-  async [a.addDatabaseSubtitles]({ getters, dispatch }: any, options: AddDatabaseSubtitlesOptions) {
+  async [a.addDatabaseSubtitles](
+    { getters, dispatch, state }: any,
+    options: AddDatabaseSubtitlesOptions,
+  ) {
     return Promise.all(
       options.storedList.map(async stored => dispatch(a.addSubtitle, {
         generator: await DatabaseGenerator.from(stored),
-        playlistId: options.playlistId,
-        mediaItemId: options.mediaItemId,
+        mediaHash: state.mediaHash,
       })),
     )
       .then(() => {
@@ -472,7 +457,7 @@ const actions = {
       });
   },
   async [a.addSubtitle]({ commit, dispatch, getters }: any, options: AddSubtitleOptions) {
-    if (options.playlistId === state.playlistId && options.mediaItemId === state.mediaItemId) {
+    if (options.mediaHash === state.mediaHash) {
       const subtitleGenerator = options.generator;
       try {
         const list = getters.list as SubtitleControlListItem[];
@@ -519,7 +504,7 @@ const actions = {
       dispatch(`${id}/${subActions.delete}`);
       dispatch(a.removeSubtitle, id);
     });
-    return removeSubtitleItemsFromList(subtitles, state.playlistId, state.mediaItemId);
+    return removeSubtitleItemsFromList(subtitles, state.mediaHash);
   },
   async [a.changePrimarySubtitle]({
     dispatch, commit, getters, state,
@@ -550,14 +535,14 @@ const actions = {
     if (id && store.hasModule(id)) await dispatch(`${id}/${subActions.load}`);
   },
   async [a.storeSelectedSubtitle]({ state }: any, ids: string[]) {
-    const { allSubtitles, playlistId, mediaItemId } = state;
+    const { allSubtitles, mediaHash } = state;
     const subtitles = ids
       .filter(id => allSubtitles[id])
       .map((id) => {
         const { hash, source } = allSubtitles[id];
         return { hash, source };
       });
-    storeSelectedSubtitles(subtitles as SelectedSubtitle[], playlistId, mediaItemId);
+    storeSelectedSubtitles(subtitles as SelectedSubtitle[], mediaHash);
   },
   async [a.startAISelection]({ dispatch }: any) {
     unwatch = store.watch(
@@ -726,8 +711,8 @@ const actions = {
   },
   async [a.storeSubtitleDelays]({ getters, state }: any) {
     const { list } = getters;
-    const { playlistId, mediaItemId } = state;
-    updateSubtitleList(list, playlistId, mediaItemId);
+    const { mediaHash } = state;
+    updateSubtitleList(list, mediaHash);
   },
 };
 

--- a/src/renderer/store/mutationTypes.js
+++ b/src/renderer/store/mutationTypes.js
@@ -86,8 +86,7 @@ export const newSubtitle = {
 export const SubtitleManager = {
   setPrimarySubtitleId: 'SET_PRIMARY_SUBTITLE_ID',
   setSecondarySubtitleId: 'SET_PSECONDARY_SUBTITLE_ID',
-  setPlaylistId: 'SET_PLAYLIST_ID',
-  setMediaItemId: 'SET_MEDIA_ITEM_ID',
+  setMediaHash: 'SET_MEDIA_HASH',
   setIsRefreshing: 'SET_IS_REFRESHING',
   addSubtitleId: 'ADD_SUBTITLE_ID',
   deleteSubtitleId: 'DELETE_SUBTITLE_ID',


### PR DESCRIPTION
- Upgrade `dataDb` version to 4.
- Use `mediaHash` to store subtitle preferences.
- Fix that sometimes subtitle list cannot be stored.
- Fix that subtitle preferences may be stored incorrectly.