### PR TITLE
fix(subtitle): fix vtt subtitle parser

### DIFF
--- a/src/renderer/services/subtitle/parsers/vtt.ts
+++ b/src/renderer/services/subtitle/parsers/vtt.ts
@@ -41,7 +41,10 @@ export class VttParser implements IParser {
           start: toMS(subtitle.start) / 1000,
           end: toMS(subtitle.end) / 1000,
           tags: tagsGetter(subtitle.text, this.baseTags),
-          text: subtitle.text.replace(/\{[^{}]*\}/g, '').replace(/[\\/][Nn]|\r?\n|\r/g, '\n'),
+          text: subtitle.text
+            .replace(/<\/?[^bius]+?>/g, '')
+            .replace(/\{[^{}]*\}/g, '')
+            .replace(/[\\/][Nn]|\r?\n|\r/g, '\n'),
           format: this.format,
         });
       });


### PR DESCRIPTION
- Ignore vtt's tag other than b, i, u and s.